### PR TITLE
Added mbstring.func_overload check

### DIFF
--- a/Artax.php
+++ b/Artax.php
@@ -17,6 +17,12 @@ if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50300) {
     die('Artax requires PHP 5.3 or higher' . PHP_EOL);
 }
 
+if (extension_loaded('mbstring')) { 
+    if( ini_get('mbstring.func_overload') & 2 ) { 
+        throw new \RuntimeException('Artax requires that string functions not be overloaded by "mbstring.func_overload"');
+    }
+}
+
 spl_autoload_register(function($className) {
     if (0 === strpos($className, 'Artax\\')) {
         $className = str_replace('\\', '/', $className);      


### PR DESCRIPTION
Since the request body function relies on strlen() to determine a total number of bytes, we should make sure that function isn't getting overridden by PHP's mbstring extension.
