### PR TITLE
HTTPS default port 443.

### DIFF
--- a/test/unit/Http/SuperglobalUriDetectorTest.php
+++ b/test/unit/Http/SuperglobalUriDetectorTest.php
@@ -12,6 +12,26 @@ class SuperglobalUriDetectorTest extends PHPUnit_Framework_TestCase {
                 'expectedResult' => 'http://localhost/index.html'
             )),
             array(array(
+                'REQUEST_URI' => '/index.html',
+                'HTTP_HOST' => 'localhost',
+                'SERVER_PORT' => 80,
+                'expectedResult' => 'http://localhost/index.html'
+            )),
+            array(array(
+                'REQUEST_URI' => '/index.html',
+                'HTTP_HOST' => 'localhost',
+                'SERVER_PORT' => 443,
+                'HTTPS' => true,
+                'expectedResult' => 'https://localhost/index.html'
+            )),
+            array(array(
+                'REQUEST_URI' => '/index.html',
+                'HTTP_HOST' => 'localhost',
+                'SERVER_PORT' => 80,
+                'HTTPS' => true,
+                'expectedResult' => 'https://localhost:80/index.html'
+            )),
+            array(array(
                 'REDIRECT_URL' => '/redirect.php',
                 'HTTP_HOST' => 'localhost',
                 'HTTPS' => 'off',


### PR DESCRIPTION
There is a default port for HTTPS as well. It has the number 443, that is specified by IANA:

http://www6.ietf.org/assignments/port-numbers (currently accessible)

http://www.iana.org/assignments/service-names-port-numbers (currently not really accessible)
