### PR TITLE
Fix setting TLS options

### DIFF
--- a/src/Artax/AsyncClient.php
+++ b/src/Artax/AsyncClient.php
@@ -949,7 +949,7 @@ class AsyncClient implements ObservableClient {
     }
     
     private function setTlsOptions(array $opt) {
-        $opt = array_filter(array_intersect_key($this->tlsOptions, $opt), function($k) { return !is_null($k); });
+        $opt = array_filter(array_intersect_key($opt, $this->tlsOptions), function($k) { return !is_null($k); });
         $this->tlsOptions = array_merge($this->tlsOptions, $opt);
     }
     


### PR DESCRIPTION
The parameter order used in `array_intersect_key` was causing the original settings to override the new settings, and no changes were applied.
