### PR TITLE
Combine all cookies into a single header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 #### master
 
-- Fixed a bug where the cookie extension sent one header per cookie, instead of a single header
-  containing a semicolon delimited list of cookie key/value pairs.
+- Added a `combineResponseCookies` property to the cookies extension which enables combining all
+  cookie values into a single header as some servers do not correctly handle multiple Cookie
+  headers. This behavior is off by default.
 
 #### v0.5.1
 

--- a/src/Artax/Ext/Cookies/CookieExtension.php
+++ b/src/Artax/Ext/Cookies/CookieExtension.php
@@ -10,6 +10,7 @@ class CookieExtension implements Extension {
     private $cookieJar;
     private $cookieParser;
     private $observation;
+    private $combineResponseCookies = false;
     
     function __construct(CookieJar $cookieJar = NULL, CookieParser $cookieParser = NULL) {
         $this->cookieJar = $cookieJar ?: new ArrayCookieJar;
@@ -38,19 +39,29 @@ class CookieExtension implements Extension {
         $scheme = $urlParts['scheme'];
         $domain = $urlParts['host'];
         $path = isset($urlParts['path']) ? $urlParts['path'] : '/';
-        
-        $applicableCookies = $this->cookieJar->get($domain, $path);
 
-        $cookieKeyValuePairs = [];
+        $applicableCookies = $this->cookieJar->get($domain, $path);
         
-        foreach ($applicableCookies as $cookie) {
-            if (!$cookie->getSecure() || !strcasecmp($scheme, 'https')) {
-                $cookieKeyValuePairs[] = $cookie->getName() . '=' . $cookie->getValue();
+        if ($this->combineResponseCookies) {
+            $cookieKeyValuePairs = [];
+            
+            foreach ($applicableCookies as $cookie) {
+                if (!$cookie->getSecure() || !strcasecmp($scheme, 'https')) {
+                    $cookieKeyValuePairs[] = $cookie->getName() . '=' . $cookie->getValue();
+                }
+            }
+
+            if (!empty($cookieKeyValuePairs)) {
+                $request->setHeader('Cookie', implode('; ', $cookieKeyValuePairs));
             }
         }
-
-        if (!empty($cookieKeyValuePairs)) {
-            $request->setHeader('Cookie', implode('; ', $cookieKeyValuePairs));
+        else {
+            foreach ($applicableCookies as $cookie) {
+                if (!$cookie->getSecure() || !strcasecmp($scheme, 'https')) {
+                    $cookieStr = $cookie->getName() . '=' . $cookie->getValue();
+                    $request->appendHeader('Cookie', $cookieStr);
+                }
+            }
         }
     }
     
@@ -87,4 +98,10 @@ class CookieExtension implements Extension {
         }
     }
     
+    public function combineResponseCookies($combine = true)
+    {
+        $this->combineResponseCookies = $combine;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Currently the extension appends a new Cookie header per cookie, this results in multiple Cookie headers being sent with the request, instead of a single header containing a semicolon delimited list of cookies in `key=value; key2=value2` format.
