### PR TITLE
Changed DefaultClient to not delete any existing Cookie header when cookie jar doesn't overwrite it

### DIFF
--- a/lib/DefaultClient.php
+++ b/lib/DefaultClient.php
@@ -665,7 +665,7 @@ final class DefaultClient implements Client {
 
         if (!$applicableCookies = $this->cookieJar->get($domain, $path)) {
             // No cookies matched our request; we're finished.
-            return $request->withoutHeader("Cookie");
+            return $request;
         }
 
         $isRequestSecure = strcasecmp($uri->getScheme(), "https") === 0;
@@ -682,7 +682,7 @@ final class DefaultClient implements Client {
             return $request->withHeader("Cookie", \implode("; ", $cookiePairs));
         }
 
-        return $request->withoutHeader("Cookie");
+        return $request;
     }
 
     private function generateAuthorityFromUri(Uri $uri): string {


### PR DESCRIPTION
There doesn't seem to be any compelling reason why, if a user has explicitly set a `Cookie` header they want to use, for the client to then delete it just because it's not also present in the "cookie jar". The cookie jar will still overwrite any existing header if it has a matching definition; this just avoids deleting the header when the cookie jar does not have any matching definition.