### PR TITLE
Ignore errors of previous connections, try to connect concurrently

### DIFF
--- a/examples/6-concurrent-requests.php
+++ b/examples/6-concurrent-requests.php
@@ -10,9 +10,9 @@ require __DIR__ . '/../vendor/autoload.php';
 
 Loop::run(static function () {
     $uris = [
-        "https://newlifecoffee.com/",
-        "https://newlifecoffee.com/coffee",
-        "https://newlifecoffee.com/images/splash/summer-coolers.png",
+        "https://google.com/",
+        "https://github.com/",
+        "https://stackoverflow.com/",
     ];
 
     // Instantiate the HTTP client

--- a/src/Connection/DefaultConnectionPool.php
+++ b/src/Connection/DefaultConnectionPool.php
@@ -65,9 +65,14 @@ final class DefaultConnectionPool implements ConnectionPool
 
             foreach ($connections as $connection) {
                 try {
-                    $connection = yield $connection;
-                } catch (CancelledException $exception) {
-                    continue; // Ignore cancellation of other requests.
+                    /** @var Promise $connection */
+                    if ($connections->count() < 4) {
+                        $connection = yield Promise\timeout($connection, 0);
+                    } else {
+                        $connection = yield $connection;
+                    }
+                } catch (\Exception $exception) {
+                    continue; // Ignore cancellations and errors of other requests.
                 }
 
                 \assert($connection instanceof Connection);

--- a/src/Response.php
+++ b/src/Response.php
@@ -2,7 +2,6 @@
 
 namespace Amp\Http\Client;
 
-use Amp\ByteStream\InMemoryStream;
 use Amp\ByteStream\InputStream;
 use Amp\ByteStream\Payload;
 use Amp\Http\Message;

--- a/test/Interceptor/AddRequestHeaderTest.php
+++ b/test/Interceptor/AddRequestHeaderTest.php
@@ -4,7 +4,6 @@ namespace Amp\Http\Client\Interceptor;
 
 class AddRequestHeaderTest extends InterceptorTest
 {
-
     public function testNetworkInterceptor(): \Generator
     {
         $this->givenNetworkInterceptor(new AddRequestHeader('foo', 'bar'));

--- a/test/Interceptor/AddResponseHeaderTest.php
+++ b/test/Interceptor/AddResponseHeaderTest.php
@@ -4,7 +4,6 @@ namespace Amp\Http\Client\Interceptor;
 
 class AddResponseHeaderTest extends InterceptorTest
 {
-
     public function testNetworkInterceptor(): \Generator
     {
         $this->givenNetworkInterceptor(new AddResponseHeader('foo', 'bar'));

--- a/test/Interceptor/InterceptorTest.php
+++ b/test/Interceptor/InterceptorTest.php
@@ -66,10 +66,13 @@ abstract class InterceptorTest extends AsyncTestCase
         parent::setUp();
 
         $this->serverSocket = SocketServer::listen('tcp://127.0.0.1:0');
-        $this->server = new Server([$this->serverSocket],
+        $this->server = new Server(
+            [$this->serverSocket],
             new CallableRequestHandler(static function () {
                 return new Response(Status::OK, ['content-type' => 'text-plain; charset=utf-8'], 'OK');
-            }), new NullLogger);
+            }),
+            new NullLogger
+        );
 
         $staticConnector = new StaticConnector($this->serverSocket->getAddress()->toString(), connector());
         $this->client = new Client(new DefaultConnectionPool($staticConnector));

--- a/test/Interceptor/RemoveRequestHeaderTest.php
+++ b/test/Interceptor/RemoveRequestHeaderTest.php
@@ -2,7 +2,6 @@
 
 namespace Amp\Http\Client\Interceptor;
 
-
 use Amp\Http\Client\Request;
 
 class RemoveRequestHeaderTest extends InterceptorTest


### PR DESCRIPTION
One connection might be enough for HTTP/2, but usually isn't for HTTP/1.