### PR TITLE
Automatically retry idempotent requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,10 @@
     "autoload": {
         "psr-4": {
             "Amp\\Http\\Client\\": "src"
-        }
+        },
+        "files": [
+            "src/functions.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -31,6 +31,8 @@ interface Connection
      */
     public function isBusy(): bool;
 
+    public function getRemainingTime(): ?int;
+
     public function close(): Promise;
 
     public function onClose(callable $onClose): void;

--- a/src/Connection/Http2Connection.php
+++ b/src/Connection/Http2Connection.php
@@ -243,6 +243,11 @@ final class Http2Connection implements Connection
         return $this->remainingStreams <= 0 || $this->socket->isClosed();
     }
 
+    public function getRemainingTime(): ?int
+    {
+        return null; // TODO Proper implementation
+    }
+
     public function onClose(callable $onClose): void
     {
         if ($this->onClose === null) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,9 @@
+<?php
+
+use Amp\Http\Client\Request;
+
+function isRetryAllowed(Request $request): bool
+{
+    // https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html
+    return \in_array($request->getMethod(), ['GET', 'HEAD', 'PUT', 'DELETE'], true);
+}


### PR DESCRIPTION
This commit adds automatic retries for idempotent methods and favors new connections for non-idempotent requests unless an explicit timeout is available.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Connection_management_in_HTTP_1.x

I'm not sure whether this should really be in `Client`, but I'd like to have it enabled by default.