### PR TITLE
Move liveliness check to Connection interface

### DIFF
--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -13,31 +13,24 @@ interface Connection
     public const MAX_KEEP_ALIVE_TIMEOUT = 60;
 
     /**
+     * @return Promise<Stream>
+     */
+    public function getStream(): Promise;
+
+    /**
      * @param Request $request
      *
-     * @return Stream
+     * @return Promise<Stream|null> Returns a stream for the given request, or null if no stream is available or if
+     *                              the connection is not suited for the given request.
      *
      * @throws SocketException If all available streams have been used. Verify a stream is available with isBusy().
      */
-    public function getStream(Request $request): Stream;
+    public function getStreamFor(Request $request): Promise;
 
     /**
      * @return string[] Array of supported protocol versions.
      */
     public function getProtocolVersions(): array;
-
-    /**
-     * @return bool True if a stream is still available, false if the connection is completely busy.
-     */
-    public function hasStreamAvailable(): bool;
-
-    /**
-     * @param Request $request
-     *
-     * @return Promise<bool> True if the connection is safe to use for a new request, false if a new connection should
-     *                       be opened.
-     */
-    public function checkLiveliness(Request $request): Promise;
 
     public function close(): Promise;
 

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -29,7 +29,13 @@ interface Connection
     /**
      * @return bool True if a stream is still available, false if the connection is completely busy.
      */
-    public function isBusy(): bool;
+    public function hasStreamAvailable(): bool;
+
+    /**
+     * @return Promise<bool> True if the connection is safe to use for a new request, false if a new connection should
+     *                       be opened.
+     */
+    public function checkLiveliness(): Promise;
 
     public function close(): Promise;
 

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -32,10 +32,12 @@ interface Connection
     public function hasStreamAvailable(): bool;
 
     /**
+     * @param Request $request
+     *
      * @return Promise<bool> True if the connection is safe to use for a new request, false if a new connection should
      *                       be opened.
      */
-    public function checkLiveliness(): Promise;
+    public function checkLiveliness(Request $request): Promise;
 
     public function close(): Promise;
 

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -3,7 +3,6 @@
 namespace Amp\Http\Client\Connection;
 
 use Amp\Http\Client\Request;
-use Amp\Http\Client\SocketException;
 use Amp\Promise;
 use Amp\Socket\SocketAddress;
 use Amp\Socket\TlsInfo;
@@ -13,19 +12,13 @@ interface Connection
     public const MAX_KEEP_ALIVE_TIMEOUT = 60;
 
     /**
-     * @return Promise<Stream>
-     */
-    public function getStream(): Promise;
-
-    /**
      * @param Request $request
      *
      * @return Promise<Stream|null> Returns a stream for the given request, or null if no stream is available or if
-     *                              the connection is not suited for the given request.
-     *
-     * @throws SocketException If all available streams have been used. Verify a stream is available with isBusy().
+     *                              the connection is not suited for the given request. The first request for a stream
+     *                              on a new connection MUST resolve the promise with a Stream instance.
      */
-    public function getStreamFor(Request $request): Promise;
+    public function getStream(Request $request): Promise;
 
     /**
      * @return string[] Array of supported protocol versions.

--- a/src/Connection/DefaultConnectionPool.php
+++ b/src/Connection/DefaultConnectionPool.php
@@ -100,16 +100,16 @@ final class DefaultConnectionPool implements ConnectionPool
 
                 \assert($connection instanceof Connection);
 
-                if ($connection->hasStreamAvailable()) {
-                    continue; // Connection is currently used to full capacity.
-                }
-
                 if (!\array_intersect($request->getProtocolVersions(), $connection->getProtocolVersions())) {
                     continue; // Connection does not support any of the requested protocol versions.
                 }
 
-                if (!yield $connection->checkLiveliness()) {
-                    continue;
+                if (!yield $connection->checkLiveliness($request)) {
+                    continue; // Connection is not suited for this request.
+                }
+
+                if ($connection->hasStreamAvailable()) {
+                    continue; // Connection is currently used to full capacity.
                 }
 
                 return $connection->getStream($request);

--- a/src/Connection/Http1Connection.php
+++ b/src/Connection/Http1Connection.php
@@ -89,9 +89,9 @@ final class Http1Connection implements Connection
         return !$this->busy && !$this->socket->isClosed();
     }
 
-    public function checkLiveliness(): Promise
+    public function checkLiveliness(Request $request): Promise
     {
-        return new Success($this->getRemainingTime() > $this->timeoutGracePeriod);
+        return new Success($this->getRemainingTime() > $this->timeoutGracePeriod || $request->isIdempotent());
     }
 
     public function onClose(callable $onClose): void

--- a/src/Connection/Http2Connection.php
+++ b/src/Connection/Http2Connection.php
@@ -258,7 +258,7 @@ final class Http2Connection implements Connection
         return $this->remainingStreams > 0 && $this->onClose !== null;
     }
 
-    public function checkLiveliness(): Promise
+    public function checkLiveliness(Request $request): Promise
     {
         if (!$this->isIdle()) {
             return new Success(true);


### PR DESCRIPTION
This is an attempt to add a method to the `Connection` interface that can be used test a connection to determine if it should be used for a request, particular a non-idempotent request.

Not sure on naming or the approach for HTTP/1.x connections.