### PR TITLE
Forbid user info component in URIs

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -91,6 +91,12 @@ final class Client
             return $this->retryInterceptor->request($request, $cancellation, $client);
         }
 
+        if ($request->getUri()->getUserInfo() !== '') {
+            throw new \Error('The user information (username:password) component of URIs has been deprecated '
+                . '(see https://tools.ietf.org/html/rfc3986#section-3.2.1 and https://tools.ietf.org/html/rfc7230#section-2.7.1); '
+                . 'Instead, set an "Authorization" header containing "Basic " . \\base64_encode("username:password")');
+        }
+
         return call(function () use ($request, $cancellation) {
             $stream = yield $this->connectionPool->getStream($request, $cancellation);
 

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -1,0 +1,26 @@
+<?php /** @noinspection PhpUnhandledExceptionInspection */
+
+namespace Amp\Http\Client\Test;
+
+use Amp\Http\Client\Client;
+use Amp\PHPUnit\AsyncTestCase;
+use Amp\Promise;
+
+class ClientTest extends AsyncTestCase
+{
+    private $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client = new Client;
+    }
+
+    public function testUserInfoDeprecation(): Promise
+    {
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('has been deprecated');
+
+        return $this->client->request('https://username:password@localhost');
+    }
+}

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -3,6 +3,7 @@
 namespace Amp\Http\Client\Test;
 
 use Amp\Http\Client\Client;
+use Amp\Http\Client\HttpException;
 use Amp\PHPUnit\AsyncTestCase;
 use Amp\Promise;
 
@@ -18,7 +19,7 @@ class ClientTest extends AsyncTestCase
 
     public function testUserInfoDeprecation(): Promise
     {
-        $this->expectException(\Error::class);
+        $this->expectException(HttpException::class);
         $this->expectExceptionMessage('has been deprecated');
 
         return $this->client->request('https://username:password@localhost');


### PR DESCRIPTION
Alternative to #209, forbidding the user info component in request URIs.

The placement of the check in `Client` is to allow an application interceptor to set an *Authorization* header if desired. Otherwise if we want to totally disallow it, the check could be moved higher.