### PR TITLE
Keep content-encoding in a request attribute when using HTTP compression

### DIFF
--- a/examples/basic/5-unix-sockets.php
+++ b/examples/basic/5-unix-sockets.php
@@ -7,15 +7,15 @@ use Amp\Http\Client\HttpException;
 use Amp\Http\Client\Request;
 use Amp\Http\Client\Response;
 use Amp\Loop;
-use Amp\Socket\DnsConnector;
 use Amp\Socket\StaticConnector;
+use function Amp\Socket\connector;
 
 require __DIR__ . '/../.helper/functions.php';
 
 Loop::run(static function () use ($argv) {
     try {
         // Unix sockets require a socket pool that changes all URLs to a fixed one.
-        $connector = new StaticConnector("unix:///var/run/docker.sock", new DnsConnector);
+        $connector = new StaticConnector("unix:///var/run/docker.sock", connector());
 
         $client = (new HttpClientBuilder)
             ->usingPool(new UnlimitedConnectionPool(new DefaultConnectionFactory($connector)))

--- a/src/Interceptor/DecompressResponse.php
+++ b/src/Interceptor/DecompressResponse.php
@@ -19,6 +19,8 @@ final class DecompressResponse implements NetworkInterceptor
     use ForbidCloning;
     use ForbidSerialization;
 
+    public const CONTENT_ENCODING_ATTR = 'amp.http.client.decompress.content-encoding';
+
     private $hasZlib;
 
     public function __construct()
@@ -61,6 +63,7 @@ final class DecompressResponse implements NetworkInterceptor
             $sizeLimit = $response->getRequest()->getBodySizeLimit();
             $decompressedBody = new ZlibInputStream($response->getBody(), $encoding);
 
+            $response->getRequest()->setAttribute(self::CONTENT_ENCODING_ATTR, $response->getHeader('content-encoding'));
             $response->setBody(new SizeLimitingInputStream($decompressedBody, $sizeLimit));
             $response->removeHeader('content-encoding');
         }

--- a/test/ClientHttpBinIntegrationTest.php
+++ b/test/ClientHttpBinIntegrationTest.php
@@ -456,6 +456,7 @@ class ClientHttpBinIntegrationTest extends AsyncTestCase
 
         $this->assertTrue($result['gzipped']);
         $this->assertFalse($response->hasHeader('content-encoding'));
+        $this->assertSame('gzip', $response->getRequest()->getAttribute(DecompressResponse::CONTENT_ENCODING_ATTR));
     }
 
     /**


### PR DESCRIPTION
Removing this header means the consumer cannot assert if compression was used or not.
And keeping it doesn't hurt in any way:
- if the request is done *with* an `Accept-Encoding`, the interceptor already and correctly does nothing.
- if the request is done *without* this request header, the client knows about it, so that it knows it should do nothing when `Content-Encoding` is found in the response.

Note that this is how curl-based clients work and this is fine and more useful.
This is needed to resolve https://github.com/symfony/symfony/pull/35115#pullrequestreview-337185999