### PR TITLE
Add Request::onInformationalResponseHandler() to process e.g. 103 Early Hints

### DIFF
--- a/src/Connection/Http1Connection.php
+++ b/src/Connection/Http1Connection.php
@@ -323,6 +323,12 @@ final class Http1Connection implements Connection
                 }
 
                 if ($status < 200) { // 1XX responses (excluding 101, handled above)
+                    $onInformationalResponse = $request->getInformationalResponseHandler();
+
+                    if ($onInformationalResponse !== null) {
+                        yield call($onInformationalResponse, $response);
+                    }
+
                     $chunk = $parser->getBuffer();
                     $parser = new Http1Parser($request, $bodyCallback, $trailersCallback);
                     goto parseChunk;

--- a/src/Connection/Internal/Http2ConnectionProcessor.php
+++ b/src/Connection/Internal/Http2ConnectionProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Amp\Http\Client\Connection\Internal;
 
+use Amp\ByteStream\InMemoryStream;
 use Amp\ByteStream\IteratorStream;
 use Amp\ByteStream\StreamException;
 use Amp\CancellationToken;
@@ -405,10 +406,6 @@ final class Http2ConnectionProcessor implements Http2Processor
             return;
         }
 
-        if ($status < 200) {
-            return; // ignore 1xx responses
-        }
-
         asyncCall(function () use ($stream, $streamId) {
             try {
                 foreach ($stream->request->getEventListeners() as $eventListener) {
@@ -419,6 +416,31 @@ final class Http2ConnectionProcessor implements Http2Processor
             }
         });
 
+        $response = new Response(
+            '2',
+            $status,
+            Status::getReason($status),
+            $headers,
+            new InMemoryStream,
+            $stream->request
+        );
+
+        if ($status < 200) {
+            $onInformationalResponse = $stream->request->getInformationalResponseHandler();
+
+            if ($onInformationalResponse !== null) {
+                asyncCall(function () use ($onInformationalResponse, $response, $streamId) {
+                    try {
+                        yield call($onInformationalResponse, $response);
+                    } catch (\Throwable $e) {
+                        $this->handleStreamException(new Http2StreamException('Informational response handler threw an exception', $streamId, self::CANCEL));
+                    }
+                });
+            }
+
+            return;
+        }
+
         $stream->body = new Emitter;
         $stream->trailers = new Deferred;
 
@@ -428,18 +450,13 @@ final class Http2ConnectionProcessor implements Http2Processor
             $bodyCancellation->getToken()
         );
 
-        $response = new Response(
-            '2',
-            $status,
-            Status::getReason($status),
-            $headers,
+        $response->setBody(
             new ResponseBodyStream(
                 new IteratorStream($stream->body->iterate()),
                 $bodyCancellation
-            ),
-            $stream->request,
-            $stream->trailers->promise()
+            )
         );
+        $response->setTrailers($stream->trailers->promise());
 
         $stream->responsePending = false;
         $stream->pendingResponse->resolve(call(static function () use ($response, $stream) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -63,6 +63,9 @@ final class Request extends Message
     /** @var callable|null */
     private $onUpgrade;
 
+    /** @var callable|null */
+    private $onInformationalResponse;
+
     /** @var mixed[] */
     private $attributes = [];
 
@@ -319,6 +322,24 @@ final class Request extends Message
     public function getUpgradeHandler(): ?callable
     {
         return $this->onUpgrade;
+    }
+
+    /**
+     * Registers a callback invoked when a 1xx response is returned to the request (other than a 101).
+     *
+     * @param callable|null $onInformationalResponse
+     */
+    public function setInformationalResponseHandler(?callable $onInformationalResponse): void
+    {
+        $this->onInformationalResponse = $onInformationalResponse;
+    }
+
+    /**
+     * @return callable|null
+     */
+    public function getInformationalResponseHandler(): ?callable
+    {
+        return $this->onInformationalResponse;
     }
 
     /**


### PR DESCRIPTION
Will be required to complete https://github.com/symfony/symfony/pull/35115
Draft state for now until I confirm this allows passing the `testInformationalResponseStream()` test case.
Still, WDYT?

See https://evertpot.com/http/103-early-hints