### PR TITLE
Add branch-alias in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,5 +70,10 @@
         "cs": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix -v --diff --dry-run",
         "cs-fix": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix -v --diff",
         "test": "@php -dzend.assertions=1 -dassert.exception=1 ./vendor/bin/phpunit --coverage-text"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "4.x-dev"
+        }
     }
 }


### PR DESCRIPTION
The missing branch-alias prevents us from installing dev-master easily.