### PR TITLE
Await events @ HTTP/2

### DIFF
--- a/src/Connection/Internal/Http2ConnectionProcessor.php
+++ b/src/Connection/Internal/Http2ConnectionProcessor.php
@@ -409,7 +409,7 @@ final class Http2ConnectionProcessor implements Http2Processor
             return;
         }
 
-        \assert($stream->preResponseResolution);
+        \assert($stream->preResponseResolution === null);
 
         $stream->preResponseResolution = call(function () use ($stream, $streamId) {
             try {

--- a/src/Connection/Internal/Http2Stream.php
+++ b/src/Connection/Internal/Http2Stream.php
@@ -10,6 +10,7 @@ use Amp\Http\Client\Internal\ForbidCloning;
 use Amp\Http\Client\Internal\ForbidSerialization;
 use Amp\Http\Client\Request;
 use Amp\Http\Client\Response;
+use Amp\Promise;
 use Amp\Struct;
 
 /**
@@ -32,8 +33,11 @@ final class Http2Stream
     /** @var Response|null */
     public $response;
 
-    /** @var Deferred */
+    /** @var Deferred|null */
     public $pendingResponse;
+
+    /** @var Promise|null */
+    public $preResponseResolution;
 
     /** @var bool */
     public $responsePending = true;


### PR DESCRIPTION
Not sure whether HTTP/1 or HTTP/2 is better in calling `startReceivingResponse`, technically, these are indeed two responses that are started, but one is only intermediate. Should it trigger for the intermediate, the actual response or both?