### PR TITLE
Add inactivity timeout

### DIFF
--- a/src/Connection/Http1Connection.php
+++ b/src/Connection/Http1Connection.php
@@ -32,9 +32,9 @@ use Amp\Socket\SocketAddress;
 use Amp\Socket\TlsInfo;
 use Amp\Success;
 use Amp\TimeoutCancellationToken;
+use Amp\TimeoutException as PromiseTimeoutException;
 use function Amp\asyncCall;
 use function Amp\call;
-use function Amp\getCurrentTime;
 
 /**
  * Socket client implementation.
@@ -92,7 +92,7 @@ final class Http1Connection implements Connection
         $this->remoteAddress = $socket->getRemoteAddress();
         $this->tlsInfo = $socket->getTlsInfo();
         $this->timeoutGracePeriod = $timeoutGracePeriod;
-        $this->lastUsedAt = getCurrentTime();
+        $this->lastUsedAt = Loop::now();
     }
 
     public function __destruct()
@@ -279,14 +279,20 @@ final class Http1Connection implements Connection
         $parser = new Http1Parser($request, $bodyCallback, $trailersCallback);
 
         $start = getCurrentTime();
+        $timeout = $request->getInactivityTimeout();
+        if ($timeout <= 0) {
+            $timeout = self::MAX_KEEP_ALIVE_TIMEOUT * 1000;
+        }
 
         try {
-            while (null !== $chunk = yield $this->socket->read()) {
+            while (null !== $chunk = yield Promise\timeout($this->socket->read(), $timeout)) {
                 parseChunk:
                 $response = $parser->parse($chunk);
                 if ($response === null) {
                     continue;
                 }
+
+                $this->lastUsedAt = Loop::now();
 
                 $status = $response->getStatus();
 
@@ -362,6 +368,7 @@ final class Http1Connection implements Connection
                     $readingCancellation,
                     $bodyCancellationToken,
                     $stream,
+                    $timeout,
                     &$backpressure,
                     &$trailers
                 ) {
@@ -374,24 +381,25 @@ final class Http1Connection implements Connection
                             // to resolve promise with headers.
                             $chunk = null;
 
-                            /** @psalm-suppress PossiblyNullReference */
-                            do {
-                                /** @noinspection CallableParameterUseCaseInTypeContextInspection */
-                                $parser->parse($chunk);
-                                /** @noinspection NotOptimalIfConditionsInspection */
-                                if ($parser->isComplete()) {
-                                    break;
-                                }
+                            try {
+                                /** @psalm-suppress PossiblyNullReference */
+                                do {
+                                    /** @noinspection CallableParameterUseCaseInTypeContextInspection */
+                                    $parser->parse($chunk);
+                                    /** @noinspection NotOptimalIfConditionsInspection */
+                                    if ($parser->isComplete()) {
+                                        break;
+                                    }
 
-                                if (!$backpressure instanceof Success) {
-                                    yield $this->withCancellation($backpressure, $bodyCancellationToken);
-                                }
-
-                                /** @psalm-suppress TypeDoesNotContainNull */
-                                if ($this->socket === null) {
-                                    throw new SocketException('Socket closed prior to response completion');
-                                }
-                            } while (null !== $chunk = yield $this->socket->read());
+                                    /** @psalm-suppress TypeDoesNotContainNull */
+                                    if (!$backpressure instanceof Success) {
+                                        yield $this->withCancellation($backpressure, $bodyCancellationToken);
+                                    }
+                                } while (null !== $chunk = yield Promise\timeout($this->socket->read(), $timeout));
+                            } catch (PromiseTimeoutException $e) {
+                                $this->close();
+                                throw new TimeoutException('Receiving the response timed out due to inactivity', 0, $e);
+                            }
 
                             $originalCancellation->throwIfRequested();
 
@@ -453,8 +461,12 @@ final class Http1Connection implements Connection
                 \strlen($parser->getBuffer()),
                 getCurrentTime() - $start
             ));
-        } catch (StreamException $e) {
-            throw new SocketException('Receiving the response headers failed: ' . $e->getMessage());
+        } catch (PromiseTimeoutException $e) {
+            $this->close();
+            throw new TimeoutException('Receiving the response timed out due to inactivity', 0, $e);
+        } catch (\Throwable $e) {
+            $this->close();
+            throw new SocketException('Receiving the response headers failed: ' . $e->getMessage(), 0, $e);
         }
     }
 

--- a/src/Connection/Http1Connection.php
+++ b/src/Connection/Http1Connection.php
@@ -396,6 +396,11 @@ final class Http1Connection implements Connection
                                     if (!$backpressure instanceof Success) {
                                         yield $this->withCancellation($backpressure, $bodyCancellationToken);
                                     }
+
+                                    /** @psalm-suppress TypeDoesNotContainNull */
+                                    if ($this->socket === null) {
+                                        throw new SocketException('Socket closed prior to response completion');
+                                    }
                                 } while (null !== $chunk = yield $timeout > 0
                                     ? Promise\timeout($this->socket->read(), $timeout)
                                     : $this->socket->read()

--- a/src/Connection/Http1Connection.php
+++ b/src/Connection/Http1Connection.php
@@ -35,6 +35,7 @@ use Amp\TimeoutCancellationToken;
 use Amp\TimeoutException as PromiseTimeoutException;
 use function Amp\asyncCall;
 use function Amp\call;
+use function Amp\getCurrentTime;
 
 /**
  * Socket client implementation.
@@ -92,7 +93,7 @@ final class Http1Connection implements Connection
         $this->remoteAddress = $socket->getRemoteAddress();
         $this->tlsInfo = $socket->getTlsInfo();
         $this->timeoutGracePeriod = $timeoutGracePeriod;
-        $this->lastUsedAt = Loop::now();
+        $this->lastUsedAt = getCurrentTime();
     }
 
     public function __destruct()
@@ -287,7 +288,7 @@ final class Http1Connection implements Connection
                     continue;
                 }
 
-                $this->lastUsedAt = Loop::now();
+                $this->lastUsedAt = getCurrentTime();
 
                 $status = $response->getStatus();
 

--- a/src/Connection/Http1Connection.php
+++ b/src/Connection/Http1Connection.php
@@ -392,7 +392,6 @@ final class Http1Connection implements Connection
                                         break;
                                     }
 
-                                    /** @psalm-suppress TypeDoesNotContainNull */
                                     if (!$backpressure instanceof Success) {
                                         yield $this->withCancellation($backpressure, $bodyCancellationToken);
                                     }

--- a/src/Connection/Http1Connection.php
+++ b/src/Connection/Http1Connection.php
@@ -113,7 +113,10 @@ final class Http1Connection implements Connection
 
     public function close(): Promise
     {
-        $this->socket->close();
+        if ($this->socket) {
+            $this->socket->close();
+        }
+
         return $this->free();
     }
 
@@ -154,6 +157,8 @@ final class Http1Connection implements Connection
 
     private function free(): Promise
     {
+        $this->socket = null;
+
         $this->lastUsedAt = 0;
 
         if ($this->timeoutWatcher !== null) {

--- a/src/Connection/Http1Connection.php
+++ b/src/Connection/Http1Connection.php
@@ -397,7 +397,7 @@ final class Http1Connection implements Connection
                                 );
                             } catch (PromiseTimeoutException $e) {
                                 $this->close();
-                                throw new TimeoutException('Inactivity timeout exceeded, took longer than ' . $timeout . ' ms', 0, $e);
+                                throw new TimeoutException('Inactivity timeout exceeded, more than ' . $timeout . ' ms elapsed from last data received', 0, $e);
                             }
 
                             $originalCancellation->throwIfRequested();
@@ -465,7 +465,7 @@ final class Http1Connection implements Connection
             throw $e;
         } catch (PromiseTimeoutException $e) {
             $this->close();
-            throw new TimeoutException('Receiving the response timed out due to inactivity', 0, $e);
+            throw new TimeoutException('Inactivity timeout exceeded, more than ' . $timeout . ' ms elapsed from last data received', 0, $e);
         } catch (\Throwable $e) {
             $this->close();
             throw new SocketException('Receiving the response headers failed: ' . $e->getMessage(), 0, $e);

--- a/src/Connection/Http2Connection.php
+++ b/src/Connection/Http2Connection.php
@@ -7,7 +7,6 @@ use Amp\Http\Client\Connection\Internal\Http2ConnectionProcessor;
 use Amp\Http\Client\Internal\ForbidCloning;
 use Amp\Http\Client\Internal\ForbidSerialization;
 use Amp\Http\Client\Request;
-use Amp\Http\Http2\Http2Processor;
 use Amp\Promise;
 use Amp\Socket\EncryptableSocket;
 use Amp\Socket\SocketAddress;

--- a/src/Connection/Internal/Http2ConnectionProcessor.php
+++ b/src/Connection/Internal/Http2ConnectionProcessor.php
@@ -1636,7 +1636,11 @@ final class Http2ConnectionProcessor implements Http2Processor
                 \pack("N", Http2Parser::CANCEL)
             );
 
-            $this->releaseStream($streamId, new TimeoutException('Inactivity timeout exceeded, took longer than ' . $timeout . ' ms'));
+            $this->releaseStream(
+                $streamId,
+                new TimeoutException('Inactivity timeout exceeded, more than '
+                    . $timeout . ' ms elapsed from last data received')
+            );
         });
 
         Loop::unreference($watcher);

--- a/src/Connection/Internal/Http2ConnectionProcessor.php
+++ b/src/Connection/Internal/Http2ConnectionProcessor.php
@@ -217,7 +217,6 @@ final class Http2ConnectionProcessor implements Http2Processor
         }
 
         $stream = $this->streams[$streamId];
-        $stream->resetInactivityWatcher();
 
         if ($stream->clientWindow + $windowSize > 2147483647) {
             $this->handleStreamException(new Http2StreamException(
@@ -714,7 +713,6 @@ final class Http2ConnectionProcessor implements Http2Processor
         }
 
         $stream = $this->streams[$streamId];
-        $stream->resetInactivityWatcher();
 
         $stream->dependency = $parentId;
         $stream->weight = $weight;

--- a/src/Connection/Internal/Http2Stream.php
+++ b/src/Connection/Internal/Http2Stream.php
@@ -10,6 +10,7 @@ use Amp\Http\Client\Internal\ForbidCloning;
 use Amp\Http\Client\Internal\ForbidSerialization;
 use Amp\Http\Client\Request;
 use Amp\Http\Client\Response;
+use Amp\Loop;
 use Amp\Promise;
 use Amp\Struct;
 
@@ -87,12 +88,19 @@ final class Http2Stream
     /** @var Deferred|null */
     public $windowSizeIncrease;
 
+    /** @var string|null */
+    public $watcher;
+
+    /** @var int */
+    public $lastActivityAt;
+
     public function __construct(
         int $id,
         Request $request,
         Stream $stream,
         CancellationToken $cancellationToken,
         CancellationToken $originalCancellation,
+        ?string $watcher,
         int $serverSize,
         int $clientSize
     ) {
@@ -101,9 +109,19 @@ final class Http2Stream
         $this->stream = $stream;
         $this->cancellationToken = $cancellationToken;
         $this->originalCancellation = $originalCancellation;
+        $this->watcher = $watcher;
         $this->serverWindow = $serverSize;
         $this->clientWindow = $clientSize;
         $this->pendingResponse = new Deferred;
         $this->requestBodyCompletion = new Deferred;
+
+        $this->lastActivityAt = Loop::now();
+    }
+
+    public function __destruct()
+    {
+        if ($this->watcher !== null) {
+            Loop::cancel($this->watcher);
+        }
     }
 }

--- a/src/Connection/Internal/Http2Stream.php
+++ b/src/Connection/Internal/Http2Stream.php
@@ -89,10 +89,7 @@ final class Http2Stream
     public $windowSizeIncrease;
 
     /** @var string|null */
-    public $watcher;
-
-    /** @var int */
-    public $lastActivityAt;
+    private $watcher;
 
     public function __construct(
         int $id,
@@ -114,8 +111,6 @@ final class Http2Stream
         $this->clientWindow = $clientSize;
         $this->pendingResponse = new Deferred;
         $this->requestBodyCompletion = new Deferred;
-
-        $this->lastActivityAt = Loop::now();
     }
 
     public function __destruct()
@@ -123,5 +118,15 @@ final class Http2Stream
         if ($this->watcher !== null) {
             Loop::cancel($this->watcher);
         }
+    }
+
+    public function resetInactivityWatcher(): void
+    {
+        if ($this->watcher === null) {
+            return;
+        }
+
+        Loop::disable($this->watcher);
+        Loop::enable($this->watcher);
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -58,7 +58,10 @@ final class Request extends Message
     private $tlsHandshakeTimeout = 10000;
 
     /** @var int */
-    private $transferTimeout = 10000;
+    private $transferTimeout = 60000;
+
+    /** @var int */
+    private $inactivityTimeout = 5000;
 
     /** @var int */
     private $bodySizeLimit = self::DEFAULT_BODY_SIZE_LIMIT;
@@ -389,6 +392,19 @@ final class Request extends Message
     public function setTransferTimeout(int $transferTimeout): void
     {
         $this->transferTimeout = $transferTimeout;
+    }
+
+    /**
+     * @return int Timeout in milliseconds since the last data was received before the request fails due to inactivity.
+     */
+    public function getInactivityTimeout(): int
+    {
+        return $this->inactivityTimeout;
+    }
+
+    public function setInactivityTimeout(int $inactivityTimeout): void
+    {
+        $this->inactivityTimeout = $inactivityTimeout;
     }
 
     public function getHeaderSizeLimit(): int

--- a/src/Request.php
+++ b/src/Request.php
@@ -58,10 +58,10 @@ final class Request extends Message
     private $tlsHandshakeTimeout = 10000;
 
     /** @var int */
-    private $transferTimeout = 60000;
+    private $transferTimeout = 10000;
 
     /** @var int */
-    private $inactivityTimeout = 5000;
+    private $inactivityTimeout = 10000;
 
     /** @var int */
     private $bodySizeLimit = self::DEFAULT_BODY_SIZE_LIMIT;

--- a/test/ClientHttpBinIntegrationTest.php
+++ b/test/ClientHttpBinIntegrationTest.php
@@ -55,8 +55,6 @@ class ClientHttpBinIntegrationTest extends AsyncTestCase
     {
         $this->givenRawServerResponse("");
 
-        $this->client = $this->builder->retry(0)->build();
-
         $this->expectException(SocketException::class);
         $this->expectExceptionMessageMatches("(Receiving the response headers for '.*' failed, because the socket to '.*' @ '.*' closed early)");
 
@@ -707,7 +705,7 @@ class ClientHttpBinIntegrationTest extends AsyncTestCase
     {
         parent::setUp();
 
-        $this->builder = new HttpClientBuilder;
+        $this->builder = (new HttpClientBuilder)->retry(0);
         $this->client = $this->builder->build();
 
         if ($this->socket) {

--- a/test/Connection/Http1ConnectionTest.php
+++ b/test/Connection/Http1ConnectionTest.php
@@ -181,7 +181,7 @@ class Http1ConnectionTest extends AsyncTestCase
             yield $response->getBody()->buffer();
             $this->fail("The request should have timed out");
         } catch (TimeoutException $exception) {
-            $this->assertStringContainsString('inactivity', $exception->getMessage());
+            $this->assertStringContainsString('Inactivity timeout', $exception->getMessage());
         }
     }
 

--- a/test/Connection/Http2ConnectionTest.php
+++ b/test/Connection/Http2ConnectionTest.php
@@ -213,7 +213,7 @@ class Http2ConnectionTest extends AsyncTestCase
         $this->assertSame(200, $response->getStatus());
 
         try {
-            $this->assertSame('test', yield $response->getBody()->buffer());
+            yield $response->getBody()->buffer();
             $this->fail("The request body should have been cancelled");
         } catch (CancelledException $exception) {
             $buffer = yield $server->read();
@@ -264,7 +264,7 @@ class Http2ConnectionTest extends AsyncTestCase
         $this->assertSame(200, $response->getStatus());
 
         try {
-            $this->assertSame('test', yield $response->getBody()->buffer());
+            yield $response->getBody()->buffer();
             $this->fail("The request body should have been cancelled");
         } catch (TimeoutException $exception) {
             $buffer = yield $server->read();
@@ -343,6 +343,57 @@ class Http2ConnectionTest extends AsyncTestCase
         } catch (CancelledException $exception) {
             $buffer = yield $server->read();
             $expected = self::packFrame(\pack("N", Http2Parser::CANCEL), Http2Parser::RST_STREAM, Http2Parser::NO_FLAG, 3);
+            $this->assertStringEndsWith($expected, $buffer);
+        }
+    }
+
+    public function testInactivityWhileStreamingBody(): \Generator
+    {
+        $hpack = new HPack;
+
+        [$server, $client] = Socket\createPair();
+
+        $connection = new Http2Connection($client);
+
+        $server->write(self::packFrame('', Http2Parser::SETTINGS, 0, 0));
+
+        yield $connection->initialize();
+
+        $request = new Request('http://localhost/');
+        $request->setInactivityTimeout(500);
+
+        /** @var Stream $stream */
+        $stream = yield $connection->getStream($request);
+
+        asyncCall(static function () use ($server, $hpack) {
+            yield delay(100);
+
+            $server->write(self::packFrame($hpack->encode([
+                [":status", Status::OK],
+                ["content-length", "8"],
+                ["date", formatDateHeader()],
+            ]), Http2Parser::HEADERS, Http2Parser::END_HEADERS, 1));
+
+            yield delay(100);
+
+            $server->write(self::packFrame('test', Http2Parser::DATA, Http2Parser::NO_FLAG, 1));
+
+            yield delay(1000);
+
+            $server->write(self::packFrame('test', Http2Parser::DATA, Http2Parser::END_STREAM, 1));
+        });
+
+        /** @var Response $response */
+        $response = yield $stream->request($request, new NullCancellationToken);
+
+        $this->assertSame(200, $response->getStatus());
+
+        try {
+            yield $response->getBody()->buffer();
+            $this->fail("The request body should have been cancelled");
+        } catch (TimeoutException $exception) {
+            $buffer = yield $server->read();
+            $expected = self::packFrame(\pack("N", Http2Parser::CANCEL), Http2Parser::RST_STREAM, Http2Parser::NO_FLAG, 1);
             $this->assertStringEndsWith($expected, $buffer);
         }
     }


### PR DESCRIPTION
This provides a separate timeout while waiting for the response or streaming the body. If no data is received for the response within the given number of milliseconds, the request fails similarly to the transfer timeout.