### PR TITLE
Make conflict with amphp/file lax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         }
     },
     "conflict": {
-        "amphp/file": "<0.2 || >=2"
+        "amphp/file": "<0.2"
     },
     "scripts": {
         "check": [


### PR DESCRIPTION
I'm trying to use `"amphp/file": "dev-master as 1.0.1",` in my composer.json because of https://github.com/amphp/file/commit/7dc65ffc03d236bf0465b83ed7767f043f502873 but composer refuses to install it:

```
  Problem 1
    - amphp/file dev-master conflicts with amphp/http-client[v4.2.2].
    - amphp/http-client v4.2.2 conflicts with amphp/file[dev-master].
    - amphp/file dev-master conflicts with amphp/http-client[v4.2.2].
    - Installation request for amphp/file dev-master as 1.0.1 -> satisfiable by amphp/file[dev-master].
    - Installation request for amphp/http-client (locked at v4.2.2, required as ^4.0) -> satisfiable by amphp/http-client[v4.2.2].
```

Now there are two ways to fix this:

1. Add [branch alias](https://getcomposer.org/doc/articles/aliases.md#branch-alias) to amphp/file to let composer know that dev-master is 1.x - then I could depend on `^1.0@dev`. (I'd recommend this for all repos.)
2. Remove the conflict with amphp/file v2 here. It doesn't make sense at all since v2 doesn't even exist and the constraint blocks dev versions.

Personally I'd recommend doing both.

Please fix this ASAP.