### PR TITLE
Support direct HTTP/2 connections without TLS

### DIFF
--- a/src/Connection/Internal/Http2ConnectionProcessor.php
+++ b/src/Connection/Internal/Http2ConnectionProcessor.php
@@ -1507,7 +1507,9 @@ final class Http2ConnectionProcessor implements Http2Processor
             if ($this->settings !== null) {
                 $settings = $this->settings;
                 $this->settings = null;
-                $settings->fail($reason ?? new UnprocessedRequestException(new SocketException("Connection closed")));
+
+                $message = "Connection closed before HTTP/2 settings could be received";
+                $settings->fail($reason ?? new UnprocessedRequestException(new SocketException($message)));
             }
 
             if ($this->streams) {


### PR DESCRIPTION
Inspired by https://github.com/symfony/symfony/issues/36419. In not sure whether we'll support upgrades without prior knowledge.