### PR TITLE
Fix HTTP/2 shutdown

### DIFF
--- a/src/Connection/ConnectionPool.php
+++ b/src/Connection/ConnectionPool.php
@@ -12,9 +12,9 @@ interface ConnectionPool
      * Reserve a stream for a particular request.
      *
      * @param Request           $request
-     * @param CancellationToken $token
+     * @param CancellationToken $cancellation
      *
      * @return Promise<Stream>
      */
-    public function getStream(Request $request, CancellationToken $token): Promise;
+    public function getStream(Request $request, CancellationToken $cancellation): Promise;
 }

--- a/src/Connection/HttpStream.php
+++ b/src/Connection/HttpStream.php
@@ -77,7 +77,7 @@ final class HttpStream implements Stream
         }
     }
 
-    public function request(Request $request, CancellationToken $token): Promise
+    public function request(Request $request, CancellationToken $cancellation): Promise
     {
         if ($this->releaseCallback === null) {
             throw new \Error('A stream may only be used for a single request');
@@ -85,12 +85,12 @@ final class HttpStream implements Stream
 
         $this->releaseCallback = null;
 
-        return call(function () use ($request, $token) {
+        return call(function () use ($request, $cancellation) {
             foreach ($request->getEventListeners() as $eventListener) {
                 yield $eventListener->startRequest($request);
             }
 
-            return call($this->requestCallback, $request, $token, $this);
+            return call($this->requestCallback, $request, $cancellation, $this);
         });
     }
 

--- a/src/Connection/Internal/Http2ConnectionProcessor.php
+++ b/src/Connection/Internal/Http2ConnectionProcessor.php
@@ -1602,7 +1602,8 @@ final class Http2ConnectionProcessor implements Http2Processor
                 $settings = $this->settings;
                 $this->settings = null;
 
-                $settings->fail(new UnprocessedRequestException($reason));
+                $message = "Connection closed before HTTP/2 settings could be received";
+                $settings->fail(new UnprocessedRequestException(new SocketException($message, 0, $reason)));
             }
 
             if ($this->streams) {

--- a/src/Connection/Internal/Http2ConnectionProcessor.php
+++ b/src/Connection/Internal/Http2ConnectionProcessor.php
@@ -1520,6 +1520,15 @@ final class Http2ConnectionProcessor implements Http2Processor
                 \pack("NN", $lastId, $code)
             );
 
+            if ($this->onClose !== null) {
+                $onClose = $this->onClose;
+                $this->onClose = null;
+
+                foreach ($onClose as $callback) {
+                    asyncCall($callback, $this);
+                }
+            }
+
             if ($this->settings !== null) {
                 $settings = $this->settings;
                 $this->settings = null;
@@ -1544,15 +1553,6 @@ final class Http2ConnectionProcessor implements Http2Processor
             }
 
             $this->cancelIdleWatcher();
-
-            if ($this->onClose !== null) {
-                $onClose = $this->onClose;
-                $this->onClose = null;
-
-                foreach ($onClose as $callback) {
-                    asyncCall($callback, $this);
-                }
-            }
 
             yield $goawayPromise;
 

--- a/src/Connection/Stream.php
+++ b/src/Connection/Stream.php
@@ -25,13 +25,13 @@ interface Stream extends DelegateHttpClient
      * the promise returned from the previous one must resolve successfully.
      *
      * @param Request           $request
-     * @param CancellationToken $token
+     * @param CancellationToken $cancellation
      *
      * @return Promise<Response>
      *
      * @throws \Error Thrown if this method is called more than once.
      */
-    public function request(Request $request, CancellationToken $token): Promise;
+    public function request(Request $request, CancellationToken $cancellation): Promise;
 
     public function getLocalAddress(): SocketAddress;
 

--- a/src/Connection/StreamLimitingPool.php
+++ b/src/Connection/StreamLimitingPool.php
@@ -59,14 +59,14 @@ final class StreamLimitingPool implements ConnectionPool
         $this->requestToKeyMapper = $requestToKeyMapper;
     }
 
-    public function getStream(Request $request, CancellationToken $token): Promise
+    public function getStream(Request $request, CancellationToken $cancellation): Promise
     {
-        return call(function () use ($request, $token) {
+        return call(function () use ($request, $cancellation) {
             /** @var Lock $lock */
             $lock = yield $this->semaphore->acquire(($this->requestToKeyMapper)($request));
 
             /** @var Stream $stream */
-            $stream = yield $this->delegate->getStream($request, $token);
+            $stream = yield $this->delegate->getStream($request, $cancellation);
 
             return HttpStream::fromStream(
                 $stream,

--- a/src/Interceptor/RetryRequests.php
+++ b/src/Interceptor/RetryRequests.php
@@ -4,6 +4,7 @@ namespace Amp\Http\Client\Interceptor;
 
 use Amp\CancellationToken;
 use Amp\Http\Client\ApplicationInterceptor;
+use Amp\Http\Client\Connection\Http2ConnectionException;
 use Amp\Http\Client\Connection\UnprocessedRequestException;
 use Amp\Http\Client\DelegateHttpClient;
 use Amp\Http\Client\Internal\ForbidCloning;
@@ -39,7 +40,7 @@ final class RetryRequests implements ApplicationInterceptor
                     return yield $httpClient->request(clone $request, $cancellation);
                 } catch (UnprocessedRequestException $exception) {
                     // Request was deemed retryable by connection, so carry on.
-                } catch (SocketException $exception) {
+                } catch (SocketException | Http2ConnectionException $exception) {
                     if (!$request->isIdempotent()) {
                         throw $exception;
                     }

--- a/src/Request.php
+++ b/src/Request.php
@@ -192,31 +192,31 @@ final class Request extends Message
     /**
      * Assign a value for the specified header field by replacing any existing values for that field.
      *
-     * @param string          $field Header name.
+     * @param string          $name Header name.
      * @param string|string[] $value Header value.
      */
-    public function setHeader(string $field, $value): void
+    public function setHeader(string $name, $value): void
     {
-        if (($field[0] ?? ":") === ":") {
+        if (($name[0] ?? ":") === ":") {
             throw new \Error("Header name cannot be empty or start with a colon (:)");
         }
 
-        parent::setHeader($field, $value);
+        parent::setHeader($name, $value);
     }
 
     /**
      * Assign a value for the specified header field by adding an additional header line.
      *
-     * @param string          $field Header name.
+     * @param string          $name Header name.
      * @param string|string[] $value Header value.
      */
-    public function addHeader(string $field, $value): void
+    public function addHeader(string $name, $value): void
     {
-        if (($field[0] ?? ":") === ":") {
+        if (($name[0] ?? ":") === ":") {
             throw new \Error("Header name cannot be empty or start with a colon (:)");
         }
 
-        parent::addHeader($field, $value);
+        parent::addHeader($name, $value);
     }
 
     public function setHeaders(array $headers): void

--- a/src/Response.php
+++ b/src/Response.php
@@ -170,31 +170,31 @@ final class Response extends Message
     /**
      * Assign a value for the specified header field by replacing any existing values for that field.
      *
-     * @param string          $field Header name.
+     * @param string          $name Header name.
      * @param string|string[] $value Header value.
      */
-    public function setHeader(string $field, $value): void
+    public function setHeader(string $name, $value): void
     {
-        if (($field[0] ?? ":") === ":") {
+        if (($name[0] ?? ":") === ":") {
             throw new \Error("Header name cannot be empty or start with a colon (:)");
         }
 
-        parent::setHeader($field, $value);
+        parent::setHeader($name, $value);
     }
 
     /**
      * Assign a value for the specified header field by adding an additional header line.
      *
-     * @param string          $field Header name.
+     * @param string          $name Header name.
      * @param string|string[] $value Header value.
      */
-    public function addHeader(string $field, $value): void
+    public function addHeader(string $name, $value): void
     {
-        if (($field[0] ?? ":") === ":") {
+        if (($name[0] ?? ":") === ":") {
             throw new \Error("Header name cannot be empty or start with a colon (:)");
         }
 
-        parent::addHeader($field, $value);
+        parent::addHeader($name, $value);
     }
 
     public function setHeaders(array $headers): void

--- a/test/Connection/Http2ConnectionTest.php
+++ b/test/Connection/Http2ConnectionTest.php
@@ -282,7 +282,7 @@ class Http2ConnectionTest extends AsyncTestCase
         } catch (TimeoutException $exception) {
             $buffer = yield $server->read();
             $expected = self::packFrame(\pack("N", Http2Parser::CANCEL), Http2Parser::RST_STREAM, Http2Parser::NO_FLAG, 1);
-            $this->assertStringEndsWith($expected, $buffer);
+            $this->assertStringContainsString($expected, $buffer);
         }
     }
 


### PR DESCRIPTION
GOAWAY doesn't mean we should close the connection right away, but rather that we shouldn't send any new requests on that connection.

Additionally, if we experience timeouts, ping before making a new request, to ensure that non-responsive but non-idle connections are sorted out and not reused.