### PR TITLE
Fix setBodySizeLimit(0) with HTTP/2 protocol

### DIFF
--- a/src/Connection/Internal/Http2ConnectionProcessor.php
+++ b/src/Connection/Internal/Http2ConnectionProcessor.php
@@ -835,7 +835,7 @@ final class Http2ConnectionProcessor implements Http2Processor
         $stream->received += $length;
         $stream->bufferSize += $length;
 
-        if ($stream->received >= $stream->request->getBodySizeLimit()) {
+        if ($stream->request->getBodySizeLimit() > 0 && $stream->received >= $stream->request->getBodySizeLimit()) {
             $this->handleStreamException(new Http2StreamException(
                 "Body size limit exceeded",
                 $streamId,


### PR DESCRIPTION
When setBodySizeLimit to 0 means no limit, but http2 protocol with throw 'Amp\Http\Client\Connection\Http2StreamException: Body size limit exceeded'.

fix https://github.com/amphp/http-client/issues/296