### PR TITLE
Fix issues caused by new betas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,5 +80,23 @@
         "branch-alias": {
             "dev-master": "4.x-dev"
         }
+    },
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/iggyvolz/socket"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/iggyvolz/cache"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/iggyvolz/process"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/iggyvolz/dns"
     }
+  ]
 }

--- a/composer.json
+++ b/composer.json
@@ -80,23 +80,5 @@
         "branch-alias": {
             "dev-master": "4.x-dev"
         }
-    },
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/iggyvolz/socket"
-    },
-    {
-      "type": "git",
-      "url": "https://github.com/iggyvolz/cache"
-    },
-    {
-      "type": "git",
-      "url": "https://github.com/iggyvolz/process"
-    },
-    {
-      "type": "git",
-      "url": "https://github.com/iggyvolz/dns"
     }
-  ]
 }

--- a/examples/concurrency/2-limits-per-host.php
+++ b/examples/concurrency/2-limits-per-host.php
@@ -48,7 +48,7 @@ try {
             });
         }
 
-        Future\all($futures);
+        Future\await($futures);
     }
 } catch (HttpException $error) {
     echo $error;

--- a/src/Body/FormBody.php
+++ b/src/Body/FormBody.php
@@ -2,14 +2,12 @@
 
 namespace Amp\Http\Client\Body;
 
-use Amp\ByteStream\IterableStream;
 use Amp\ByteStream\ReadableBuffer;
 use Amp\ByteStream\ReadableStream;
 use Amp\ByteStream\ReadableStreamChain;
 use Amp\Future;
 use Amp\Http\Client\RequestBody;
 use function Amp\async;
-use function Amp\Pipeline\fromIterable;
 
 final class FormBody implements RequestBody
 {

--- a/src/Connection/Http1Connection.php
+++ b/src/Connection/Http1Connection.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Http\Client\Connection;
 
-use Amp\ByteStream\IterableStream;
+use Amp\ByteStream\ReadableIterableStream;
 use Amp\ByteStream\StreamException;
 use Amp\Cancellation;
 use Amp\DeferredCancellation;
@@ -355,7 +355,7 @@ final class Http1Connection implements Connection
 
                 $response->setTrailers($trailersDeferred->getFuture());
                 $response->setBody(new ResponseBodyStream(
-                    new IterableStream($bodyEmitter->pipe()),
+                    new ReadableIterableStream($bodyEmitter->pipe()),
                     $bodyDeferredCancellation
                 ));
 

--- a/src/Connection/Http1Connection.php
+++ b/src/Connection/Http1Connection.php
@@ -25,7 +25,7 @@ use Amp\Http\Client\SocketException;
 use Amp\Http\Client\TimeoutException;
 use Amp\Http\InvalidHeaderException;
 use Amp\Http\Rfc7230;
-use Amp\Pipeline\Emitter;
+use Amp\Pipeline\Queue;
 use Amp\Socket\EncryptableSocket;
 use Amp\Socket\SocketAddress;
 use Amp\Socket\TlsInfo;
@@ -258,8 +258,8 @@ final class Http1Connection implements Connection
         Cancellation $readingCancellation,
         Stream $stream
     ): Response {
-        $bodyEmitter = new Emitter();
-        $bodyCallback = static fn (string $data) => $bodyEmitter->emit($data)->ignore();
+        $bodyEmitter = new Queue();
+        $bodyCallback = static fn (string $data) => $bodyEmitter->pushAsync($data)->ignore();
 
         $trailersDeferred = new DeferredFuture;
         $trailersDeferred->getFuture()->ignore();

--- a/src/Connection/Internal/Http2ConnectionProcessor.php
+++ b/src/Connection/Internal/Http2ConnectionProcessor.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Http\Client\Connection\Internal;
 
-use Amp\ByteStream\IterableStream;
+use Amp\ByteStream\ReadableIterableStream;
 use Amp\ByteStream\ReadableBuffer;
 use Amp\ByteStream\StreamException;
 use Amp\Cancellation;
@@ -447,7 +447,7 @@ final class Http2ConnectionProcessor implements Http2Processor
 
         $response->setBody(
             new ResponseBodyStream(
-                new IterableStream($stream->body->pipe()),
+                new ReadableIterableStream($stream->body->pipe()),
                 $bodyCancellation
             )
         );

--- a/src/Connection/Internal/Http2Stream.php
+++ b/src/Connection/Internal/Http2Stream.php
@@ -10,7 +10,7 @@ use Amp\Http\Client\Internal\ForbidCloning;
 use Amp\Http\Client\Internal\ForbidSerialization;
 use Amp\Http\Client\Request;
 use Amp\Http\Client\Response;
-use Amp\Pipeline\Emitter;
+use Amp\Pipeline\Queue;
 use Revolt\EventLoop;
 
 /**
@@ -35,7 +35,7 @@ final class Http2Stream
 
     public bool $responsePending = true;
 
-    public ?Emitter $body = null;
+    public ?Queue $body = null;
 
     public ?DeferredFuture $trailers = null;
 

--- a/test/ClientHttpBinIntegrationTest.php
+++ b/test/ClientHttpBinIntegrationTest.php
@@ -30,7 +30,6 @@ use Amp\Socket;
 use Closure;
 use Psr\Log\NullLogger;
 use Revolt\EventLoop;
-use function _HumbugBoxae3c412aa099\Amp\asyncCall;
 use function Amp\async;
 use function Amp\delay;
 use function Amp\Socket\listen;
@@ -589,7 +588,7 @@ class ClientHttpBinIntegrationTest extends AsyncTestCase
 
             public function createBodyStream(): ReadableStream
             {
-                return new IterableStream(Pipeline::fromIterable(["a", "b", "c"])->map(fn() => delay(500)));
+                return new IterableStream(Pipeline::fromIterable(["a", "b", "c"])->delay(500));
             }
 
             public function getBodyLength(): int

--- a/test/ClientHttpBinIntegrationTest.php
+++ b/test/ClientHttpBinIntegrationTest.php
@@ -21,17 +21,18 @@ use Amp\Http\Cookie\ResponseCookie;
 use Amp\Http\Rfc7230;
 use Amp\Http\Server\Options;
 use Amp\Http\Server\Request as ServerRequest;
-use Amp\Http\Server\RequestHandler\CallableRequestHandler;
+use Amp\Http\Server\RequestHandler\ClosureRequestHandler;
 use Amp\Http\Server\Response as ServerResponse;
 use Amp\Http\Server\Server;
 use Amp\PHPUnit\AsyncTestCase;
+use Amp\Pipeline\Pipeline;
 use Amp\Socket;
+use Closure;
 use Psr\Log\NullLogger;
 use Revolt\EventLoop;
+use function _HumbugBoxae3c412aa099\Amp\asyncCall;
 use function Amp\async;
 use function Amp\delay;
-use function Amp\Pipeline\fromIterable;
-use function Amp\Pipeline\postpone;
 use function Amp\Socket\listen;
 
 class ClientHttpBinIntegrationTest extends AsyncTestCase
@@ -588,7 +589,7 @@ class ClientHttpBinIntegrationTest extends AsyncTestCase
 
             public function createBodyStream(): ReadableStream
             {
-                return new IterableStream(fromIterable(["a", "b", "c"])->pipe(postpone(500)));
+                return new IterableStream(Pipeline::fromIterable(["a", "b", "c"])->map(fn() => delay(500)));
             }
 
             public function getBodyLength(): int
@@ -766,7 +767,7 @@ class ClientHttpBinIntegrationTest extends AsyncTestCase
         $this->socket = listen('127.0.0.1:0');
         $this->socket->unreference();
 
-        $this->rawHandler = EventLoop::onReadable($this->socket, function () {
+        $this->rawHandler = EventLoop::onReadable($this->socket->getResource(), function () {
             $client = $this->socket->accept();
 
             if ($client === null) {
@@ -785,14 +786,15 @@ class ClientHttpBinIntegrationTest extends AsyncTestCase
 
     private function givenServer(callable $requestHandler): void
     {
-        $this->httpServer = new Server([$this->socket], new CallableRequestHandler($requestHandler), new NullLogger,
+        $this->httpServer = new Server([$this->socket], new ClosureRequestHandler(Closure::fromCallable($requestHandler)), new NullLogger,
             (new Options)->withHttp2Upgrade());
         $this->httpServer->start();
     }
 
     private function givenRawServerResponse(string $response): void
     {
-        $this->responseCallback = static function (Socket\Socket $socket) use ($response): void {
+        $this->responseCallback = static function ($socket) use ($response): void {
+
             $buffer = '';
 
             // Await request before sending response

--- a/test/ClientHttpBinIntegrationTest.php
+++ b/test/ClientHttpBinIntegrationTest.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Http\Client;
 
-use Amp\ByteStream\IterableStream;
+use Amp\ByteStream\ReadableIterableStream;
 use Amp\ByteStream\ReadableBuffer;
 use Amp\ByteStream\ReadableStream;
 use Amp\Cancellation;
@@ -588,7 +588,7 @@ class ClientHttpBinIntegrationTest extends AsyncTestCase
 
             public function createBodyStream(): ReadableStream
             {
-                return new IterableStream(Pipeline::fromIterable(["a", "b", "c"])->delay(500));
+                return new ReadableIterableStream(Pipeline::fromIterable(["a", "b", "c"])->delay(500));
             }
 
             public function getBodyLength(): int

--- a/test/Connection/ConnectionLimitingPoolTest.php
+++ b/test/Connection/ConnectionLimitingPoolTest.php
@@ -179,7 +179,7 @@ class ConnectionLimitingPoolTest extends AsyncTestCase
                     200,
                     null,
                     [],
-                    new InMemoryStream($content),
+                    new ReadableBuffer($content),
                     $request,
                     Future::complete(new Trailers([]))
                 );

--- a/test/Connection/Http1ConnectionTest.php
+++ b/test/Connection/Http1ConnectionTest.php
@@ -12,7 +12,7 @@ use Amp\Http\Client\Response;
 use Amp\Http\Client\TimeoutException;
 use Amp\NullCancellation;
 use Amp\PHPUnit\AsyncTestCase;
-use Amp\Pipeline;
+use Amp\Pipeline\Pipeline;
 use Amp\Socket;
 use Laminas\Diactoros\Uri as LaminasUri;
 use League\Uri;
@@ -259,8 +259,8 @@ class Http1ConnectionTest extends AsyncTestCase
 
             public function createBodyStream(): ReadableStream
             {
-                $pipeline = Pipeline\fromIterable(\array_fill(0, 100, '.'));
-                $pipeline = $pipeline->pipe(Pipeline\postpone(0.1));
+                $pipeline = Pipeline::fromIterable(\array_fill(0, 100, '.'));
+                $pipeline = $pipeline->map(fn() => delay(0.1));
 
                 return new IterableStream($pipeline);
             }

--- a/test/Connection/Http1ConnectionTest.php
+++ b/test/Connection/Http1ConnectionTest.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Http\Client\Connection;
 
-use Amp\ByteStream\IterableStream;
+use Amp\ByteStream\ReadableIterableStream;
 use Amp\ByteStream\ReadableStream;
 use Amp\Http\Client\HttpException;
 use Amp\Http\Client\InvalidRequestException;
@@ -262,7 +262,7 @@ class Http1ConnectionTest extends AsyncTestCase
                 $pipeline = Pipeline::fromIterable(\array_fill(0, 100, '.'));
                 $pipeline = $pipeline->delay(0.1);
 
-                return new IterableStream($pipeline);
+                return new ReadableIterableStream($pipeline);
             }
 
             public function getBodyLength(): ?int

--- a/test/Connection/Http1ConnectionTest.php
+++ b/test/Connection/Http1ConnectionTest.php
@@ -260,7 +260,7 @@ class Http1ConnectionTest extends AsyncTestCase
             public function createBodyStream(): ReadableStream
             {
                 $pipeline = Pipeline::fromIterable(\array_fill(0, 100, '.'));
-                $pipeline = $pipeline->map(fn() => delay(0.1));
+                $pipeline = $pipeline->delay(0.1);
 
                 return new IterableStream($pipeline);
             }

--- a/test/Interceptor/InterceptorTest.php
+++ b/test/Interceptor/InterceptorTest.php
@@ -10,7 +10,7 @@ use Amp\Http\Client\HttpClientBuilder;
 use Amp\Http\Client\NetworkInterceptor;
 use Amp\Http\Client\Request as ClientRequest;
 use Amp\Http\Client\Response as ClientResponse;
-use Amp\Http\Server\RequestHandler\CallableRequestHandler;
+use Amp\Http\Server\RequestHandler\ClosureRequestHandler;
 use Amp\Http\Server\Response;
 use Amp\Http\Server\Server;
 use Amp\Http\Status;
@@ -78,7 +78,7 @@ abstract class InterceptorTest extends AsyncTestCase
         $this->serverSocket = listen('tcp://127.0.0.1:0');
         $this->server = new Server(
             [$this->serverSocket],
-            new CallableRequestHandler(static function () {
+            new ClosureRequestHandler(static function () {
                 return new Response(Status::OK, ['content-type' => 'text-plain; charset=utf-8'], 'OK');
             }),
             new NullLogger

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -88,9 +88,6 @@ class ResponseTest extends AsyncTestCase
         $response->setBody("foobar");
         $this->assertSame('foobar', $response->getBody()->buffer());
 
-        $response->setBody($response->getBody());
-        $this->assertSame('foobar', $response->getBody()->buffer());
-
         $response->setBody(new ReadableBuffer('foobar2'));
         $this->assertSame('foobar2', $response->getBody()->buffer());
 


### PR DESCRIPTION
Still have a few tests failing that I'm not quite sure how to fix but overall seems to be working after a few fixups:

- ClientHttpBinIntegrationTest::testHttp2Push `Amp\Socket\ConnectException: Connection to tcp://http2-server-push-demo.keksi.io:443 failed: [Error #101] Network is unreachable` (might be some issue with my network setup)
- ClientHttpBinIntegrationTest::testHttp2TeHeader `PHPUnit\Framework\AssertionFailedError: No response callback set`
- ClientHttpBinIntegrationTest::testFileBodyRequest, ClientHttpBinIntegrationTest::testMultipartBodyRequest, FormBodyTest::testMultiPartFields `Error: Call to undefined function Amp\Pipeline\fromIterable()` looks to be from here https://github.com/amphp/parallel/blob/1de63bae78f5bad50f31146370e015a65dc71295/src/Sync/ChannelledStream.php#L49 but updating that causes a dependency hell that I haven't been able to work out yet - might be easier to let this one sit for a bit
- ClientHttpBinIntegrationTest::testContentLengthBodyMismatch, Http1ConnectionTest::testWritingRequestWithValidUrlPathProceedsWithMatchingUriPath with data set "Empty path is replaced with slash" `Amp\ByteStream\StreamException thrown to event loop error handler: Failed to write to stream (8): fwrite(): Send of 1 bytes failed with errno=32 Broken pipe` - not sure what's going on here
-  LogIntoHttpArchiveTest::testProducesValidJson `Failed asserting that an empty string is valid JSON.`