### PR TITLE
allow also psr/http-message 2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "amphp/socket": "^1",
         "amphp/sync": "^1.3",
         "league/uri": "^6",
-        "psr/http-message": "^1"
+        "psr/http-message": "^1 | ^2"
     },
     "require-dev": {
         "ext-json": "*",


### PR DESCRIPTION
allow also psr/http-message 2.*

There is no backward incompatibility for v4 as psr/http-message for 2.0 has also PHP 7.2 as minimum requirement.

The branch 4.x can be merged into 5.x as that's valid for 5.x as well and it's not yet changed there.