### PR TITLE
Fixed form content encoding

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -165,7 +165,7 @@ final class Form implements HttpContent
             }
         }
 
-        return QueryString::build($pairs) ?? '';
+        return QueryString::build($pairs, enc_type: PHP_QUERY_RFC1738) ?? '';
     }
 
     /**


### PR DESCRIPTION
Changed form content encoding from `PHP_QUERY_RFC3986` -> `PHP_QUERY_RFC1738`. This was the default in v5.0.0-beta.7.

It seems this inadvertently changed when [http_build_query()](https://github.com/amphp/http-client/blob/v5.0.0-beta.7/src/Body/FormBody.php#L192) was replaced with `League\Uri\QueryString` for whatever reason. The [default](https://github.com/thephpleague/uri-components/blob/06f49e726a7fd06063e80f5f8b045fb9128e6c43/src/QueryString.php#L257) in that library is different.

Closes #333.