### PR TITLE
Add inactivity timeout to SetRequestTimeout interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ The big disadvantage of network interceptors is that they have to be rather quic
 - `SetRequestHeaderIfUnset`
 - `SetResponseHeader`
 - `SetResponseHeaderIfUnset`
+- `SetRequestTimeout`
 - [`CookieHandler`](https://github.com/amphp/http-client-cookies)
 - [`PrivateCache`](https://github.com/amphp/http-client-cache)
 

--- a/src/Interceptor/SetRequestTimeout.php
+++ b/src/Interceptor/SetRequestTimeout.php
@@ -10,15 +10,21 @@ final class SetRequestTimeout extends ModifyRequest
         float $tcpConnectTimeout = 10,
         float $tlsHandshakeTimeout = 10,
         float $transferTimeout = 10,
+        float $inactivityTimeout = null,
     ) {
         parent::__construct(static function (Request $request) use (
             $tcpConnectTimeout,
             $tlsHandshakeTimeout,
-            $transferTimeout
+            $transferTimeout,
+            $inactivityTimeout
         ) {
             $request->setTcpConnectTimeout($tcpConnectTimeout);
             $request->setTlsHandshakeTimeout($tlsHandshakeTimeout);
             $request->setTransferTimeout($transferTimeout);
+
+            if (null !== $inactivityTimeout) {
+                $request->setInactivityTimeout($inactivityTimeout);
+            }
 
             return $request;
         });

--- a/src/Interceptor/SetRequestTimeout.php
+++ b/src/Interceptor/SetRequestTimeout.php
@@ -10,7 +10,7 @@ final class SetRequestTimeout extends ModifyRequest
         float $tcpConnectTimeout = 10,
         float $tlsHandshakeTimeout = 10,
         float $transferTimeout = 10,
-        float $inactivityTimeout = null,
+        ?float $inactivityTimeout = null,
     ) {
         parent::__construct(static function (Request $request) use (
             $tcpConnectTimeout,


### PR DESCRIPTION
I figured out that the inactivity timeout was not present in the default interceptor in charge of updating the timeouts.

Of course it's not a big deal and here is a workaround:

```php
$this->httpClient = (new HttpClientBuilder)
    ->interceptNetwork(
        new ModifyRequest(static function (Request $request) {
            $request->setInactivityTimeout(500);

            return $request;
        })
    )
    ->build();
```

But I decided maybe it's a good first contribution here 😄 . I also updated a bit the documentation because it was missing in the interceptor list! However, I'm sorry I don't know how to fix the test.