### PR TITLE
Uri\Http deprecated

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -10,6 +10,7 @@ use Amp\Http\Client\Internal\Phase;
 use Amp\Http\HttpMessage;
 use Amp\Http\HttpRequest;
 use League\Uri;
+use League\Uri\UriString;
 use Psr\Http\Message\UriInterface;
 use function Amp\async;
 
@@ -538,7 +539,6 @@ final class Request extends HttpRequest
 
     private function createUriFromString(string $uri): UriInterface
     {
-        /** @psalm-suppress DeprecatedMethod */
-        return Uri\Http::createFromString($uri);
+        return Uri\Http::fromComponents(UriString::parse($uri));
     }
 }


### PR DESCRIPTION
From version `7.5` of `league/uri` got deprecation warning: `E_USER_DEPRECATED: Method League\Uri\Http::createFromString() is deprecated since league/uri:7.0.0, use League\Uri\Http::new() instead`

This code shoud be compatible with `league/uri` `^6|^7`