### PR TITLE
Replaced deprecated method calls from `league/uri` v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "amphp/pipeline": "^1",
         "amphp/socket": "^2",
         "amphp/sync": "^2",
-        "league/uri": "^6 | ^7",
+        "league/uri": "^7",
         "league/uri-components": "^2.4 | ^7",
         "league/uri-interfaces": "^7.1",
         "psr/http-message": "^1 | ^2"

--- a/src/Connection/Internal/Http2ConnectionProcessor.php
+++ b/src/Connection/Internal/Http2ConnectionProcessor.php
@@ -584,8 +584,7 @@ final class Http2ConnectionProcessor implements Http2Processor
         }
 
         try {
-            /** @psalm-suppress DeprecatedMethod */
-            $uri = Uri\Http::createFromComponents([
+            $uri = Uri\Http::fromComponents([
                 "scheme" => $scheme,
                 "host" => $host,
                 "port" => $port,

--- a/src/Interceptor/FollowRedirects.php
+++ b/src/Interceptor/FollowRedirects.php
@@ -248,8 +248,7 @@ final class FollowRedirects implements ApplicationInterceptor
             $header = $response->getHeader('location');
             \assert($header !== null); // see check above
 
-            /** @psalm-suppress DeprecatedMethod */
-            $locationUri = Uri\Http::createFromString($header);
+            $locationUri = Uri\Http::new($header);
         } catch (\Exception $e) {
             return null;
         }

--- a/src/Interceptor/MatchOrigin.php
+++ b/src/Interceptor/MatchOrigin.php
@@ -61,8 +61,7 @@ final class MatchOrigin implements ApplicationInterceptor
     private function checkOrigin(string $origin): string
     {
         try {
-            /** @psalm-suppress DeprecatedMethod */
-            $originUri = Http::createFromString($origin);
+            $originUri = Http::new($origin);
         } catch (\Exception) {
             throw new HttpException("Invalid origin provided: parsing failed: " . $origin);
         }

--- a/src/Interceptor/ResolveBaseUri.php
+++ b/src/Interceptor/ResolveBaseUri.php
@@ -9,9 +9,8 @@ final class ResolveBaseUri extends ModifyRequest
 {
     public function __construct(string $baseUri)
     {
-        /** @psalm-suppress DeprecatedMethod */
         parent::__construct(
-            fn (Request $request) => $request->setUri(Http::createFromBaseUri($request->getUri(), $baseUri))
+            fn (Request $request) => $request->setUri(Http::fromBaseUri($request->getUri(), $baseUri))
         );
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -538,7 +538,6 @@ final class Request extends HttpRequest
 
     private function createUriFromString(string $uri): UriInterface
     {
-        /** @psalm-suppress DeprecatedMethod */
-        return Uri\Http::createFromString($uri);
+        return Uri\Http::new($uri);
     }
 }

--- a/test/Connection/Http1ConnectionTest.php
+++ b/test/Connection/Http1ConnectionTest.php
@@ -240,7 +240,7 @@ class Http1ConnectionTest extends AsyncTestCase
         [$server, $client] = Socket\createSocketPair();
 
         $connection = new Http1Connection($client, 0, null, 5);
-        $uri = Uri\Http::createFromString('http://localhost')->withPath($requestPath);
+        $uri = Uri\Http::new('http://localhost')->withPath($requestPath);
         $request = new Request($uri);
         $request->setInactivityTimeout(0.5);
 

--- a/test/Connection/Http2ConnectionTest.php
+++ b/test/Connection/Http2ConnectionTest.php
@@ -462,7 +462,7 @@ class Http2ConnectionTest extends AsyncTestCase
         string $requestPath,
         string $expectedPath
     ): void {
-        $uri = Uri\Http::createFromString('http://localhost')->withPath($requestPath);
+        $uri = Uri\Http::new('http://localhost')->withPath($requestPath);
         $request = new Request($uri);
         $request->setInactivityTimeout(0.5);
 


### PR DESCRIPTION
This also removes support for `league/uri` v6 in lieu of v7.