### PR TITLE
Test against PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,15 @@ jobs:
           - operating-system: 'ubuntu-latest'
             php-version: '8.3'
 
+          - operating-system: 'ubuntu-latest'
+            php-version: '8.4'
+
           - operating-system: 'windows-latest'
-            php-version: '8.3'
+            php-version: '8.4'
             job-description: 'on Windows'
 
           - operating-system: 'macos-latest'
-            php-version: '8.3'
+            php-version: '8.4'
             job-description: 'on macOS'
 
     name: PHP ${{ matrix.php-version }} ${{ matrix.job-description }}

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "phpunit/phpunit": "^9",
         "amphp/http-server": "^3",
         "kelunik/link-header-rfc5988": "^1",
-        "psalm/phar": "~5.23",
+        "psalm/phar": "*",
         "laminas/laminas-diactoros": "^3.5.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "amphp/http-server": "^3",
         "kelunik/link-header-rfc5988": "^1",
         "psalm/phar": "~5.23",
-        "laminas/laminas-diactoros": "^2.3"
+        "laminas/laminas-diactoros": "^3.5.0"
     },
     "suggest": {
         "ext-zlib": "Allows using compression for response bodies.",

--- a/examples/pagination/1-iterator.php
+++ b/examples/pagination/1-iterator.php
@@ -8,7 +8,7 @@ use function Kelunik\LinkHeaderRfc5988\parseLinks;
 
 require __DIR__ . '/../.helper/functions.php';
 
-class GitHubApi
+final class GitHubApi
 {
     private HttpClient $httpClient;
 

--- a/examples/pagination/2-iterator-batch.php
+++ b/examples/pagination/2-iterator-batch.php
@@ -10,7 +10,7 @@ use function Kelunik\LinkHeaderRfc5988\parseLinks;
 
 require __DIR__ . '/../.helper/functions.php';
 
-class GitHubApi
+final class GitHubApi
 {
     private HttpClient $httpClient;
 
@@ -36,7 +36,7 @@ class GitHubApi
             $events = json_decode($json);
             yield $events;
 
-            $links = parseLinks($response->getHeader('link'));
+            $links = parseLinks($response->getHeader('link') ?? '');
             $next = $links->getByRel('next');
 
             if ($next) {

--- a/examples/streaming/1-large-response.php
+++ b/examples/streaming/1-large-response.php
@@ -47,6 +47,7 @@ try {
     print "\n";
 
     $path = tempnam(sys_get_temp_dir(), "artax-streaming-");
+    assert($path !== false);
 
     $file = Amp\File\openFile($path, "w");
 

--- a/examples/streaming/2-http1-http2.php
+++ b/examples/streaming/2-http1-http2.php
@@ -34,6 +34,7 @@ function fetch(string $uri, array $protocolVersions): void
         print "\n";
 
         $path = tempnam(sys_get_temp_dir(), "artax-streaming-");
+        assert($path !== false);
 
         $file = Amp\File\openFile($path, "w");
 

--- a/examples/streaming/3-large-response-slow-read.php
+++ b/examples/streaming/3-large-response-slow-read.php
@@ -48,6 +48,7 @@ try {
     print "\n";
 
     $path = tempnam(sys_get_temp_dir(), "artax-streaming-");
+    assert($path !== false);
 
     $file = Amp\File\openFile($path, "w");
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,9 +4,12 @@
         phpVersion="8.1"
         resolveFromConfigFile="true"
         rememberPropertyAssignmentsAfterCall="false"
+        ensureOverrideAttribute="false"
+        findUnusedCode="false"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="https://getpsalm.org/schema/config"
         xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+        xmlns:xi="http://www.w3.org/2001/XInclude"
 >
     <projectFiles>
         <directory name="examples"/>
@@ -23,6 +26,20 @@
                 <directory name="src"/>
             </errorLevel>
         </StringIncrement>
+
+        <ImplicitToStringCast>
+            <errorLevel type="suppress">
+                <directory name="examples"/>
+                <directory name="src"/>
+            </errorLevel>
+        </ImplicitToStringCast>
+
+        <InvalidOperand>
+            <errorLevel type="suppress">
+                <directory name="examples"/>
+                <directory name="src"/>
+            </errorLevel>
+        </InvalidOperand>
 
         <DuplicateClass>
             <errorLevel type="suppress">
@@ -42,12 +59,6 @@
             </errorLevel>
         </DocblockTypeContradiction>
 
-        <MissingClosureParamType>
-            <errorLevel type="suppress">
-                <directory name="src"/>
-            </errorLevel>
-        </MissingClosureParamType>
-
         <MissingClosureReturnType>
             <errorLevel type="suppress">
                 <directory name="src" />
@@ -59,5 +70,11 @@
                 <directory name="src" />
             </errorLevel>
         </RiskyTruthyFalsyComparison>
+
+        <InvalidReturnType>
+            <errorLevel type="suppress">
+                <file name="src/Connection/Internal/Http1Parser.php" />
+            </errorLevel>
+        </InvalidReturnType>
     </issueHandlers>
 </psalm>

--- a/src/Connection/Internal/Http1Parser.php
+++ b/src/Connection/Internal/Http1Parser.php
@@ -322,6 +322,8 @@ final class Http1Parser
             $rawHeaders = \preg_replace("/\r\n[\x20\t]++/", ' ', $rawHeaders);
         }
 
+        \assert($rawHeaders !== null);
+
         try {
             $headers = Rfc7230::parseHeaderPairs($rawHeaders);
             $headerMap = mapHeaderPairs($headers);

--- a/src/Connection/Internal/Http2ConnectionProcessor.php
+++ b/src/Connection/Internal/Http2ConnectionProcessor.php
@@ -1013,6 +1013,7 @@ final class Http2ConnectionProcessor implements Http2Processor
                     $this->writeFrame(Http2Parser::CONTINUATION, Http2Parser::NO_FLAG, $streamId, $headerChunk)->ignore();
                 }
 
+                \assert($lastChunk !== null);
                 $this->writeFrame(Http2Parser::CONTINUATION, $flag, $streamId, $lastChunk)->await();
             } else {
                 $this->writeFrame(Http2Parser::HEADERS, $flag, $streamId, $headers)->await();

--- a/src/EventListener/LogHttpArchive.php
+++ b/src/EventListener/LogHttpArchive.php
@@ -229,7 +229,7 @@ final class LogHttpArchive implements EventListener
                 $fileHandle->seek(-3, Whence::Current);
             }
 
-            $json = \json_encode(self::formatEntry($response));
+            $json = \json_encode(self::formatEntry($response), flags: JSON_THROW_ON_ERROR);
 
             $fileHandle->write(($firstEntry ? '' : ',') . $json . ']}}');
 

--- a/src/Interceptor/FollowRedirects.php
+++ b/src/Interceptor/FollowRedirects.php
@@ -66,6 +66,7 @@ final class FollowRedirects implements ApplicationInterceptor
         $patternE = ',(/*[^/]*),';
 
         while ($input !== '') {
+            \assert($input !== null);
             if (\preg_match($patternA, $input)) {
                 $input = \preg_replace($patternA, '', $input);
             } elseif (\preg_match($patternB1, $input, $match) || \preg_match($patternB2, $input, $match)) {
@@ -80,6 +81,7 @@ final class FollowRedirects implements ApplicationInterceptor
                 $input = \preg_replace(',^' . \preg_quote($initialSegment, ',') . ',', '', $input, 1);
                 $output .= $initialSegment;
             }
+            \assert($output !== null);
         }
 
         return $output;

--- a/src/Interceptor/RetryRequests.php
+++ b/src/Interceptor/RetryRequests.php
@@ -26,6 +26,7 @@ final class RetryRequests implements ApplicationInterceptor
         DelegateHttpClient $httpClient
     ): Response {
         $attempt = 1;
+        $exception = null;
 
         do {
             $clonedRequest = clone $request;
@@ -42,6 +43,8 @@ final class RetryRequests implements ApplicationInterceptor
                 throw $exception;
             }
         } while ($attempt++ <= $this->retryLimit);
+
+        \assert($exception !== null);
 
         throw $exception;
     }

--- a/src/Interceptor/TooManyRedirectsException.php
+++ b/src/Interceptor/TooManyRedirectsException.php
@@ -5,6 +5,9 @@ namespace Amp\Http\Client\Interceptor;
 use Amp\Http\Client\HttpException;
 use Amp\Http\Client\Response;
 
+/**
+ * @api
+ */
 class TooManyRedirectsException extends HttpException
 {
     private Response $response;


### PR DESCRIPTION
I already use the http client with PHP 8.4. But I figured out that the devkit was limited to PHP 8.3. Let's update things!


Outch. It has been a battle to update psalm configuration. I added some new rules to avoid many many MANY useless casts.

Wont be merged, see https://github.com/amphp/http-client/pull/378#issuecomment-2690292872