### PR TITLE
Throws TimeoutException when TransferTimeout is exceeded

### DIFF
--- a/src/Connection/Http1Connection.php
+++ b/src/Connection/Http1Connection.php
@@ -450,6 +450,7 @@ final class Http1Connection implements Connection
             }
 
             $originalCancellation->throwIfRequested();
+            $readingCancellation->throwIfRequested();
 
             throw new SocketException(\sprintf(
                 "Receiving the response headers for '%s' failed, because the socket to '%s' @ '%s' closed early with %d bytes received within %0.3f seconds",
@@ -468,11 +469,11 @@ final class Http1Connection implements Connection
             // Throw original cancellation if it was requested.
             $originalCancellation->throwIfRequested();
 
-            throw new TimeoutException(
-                'Inactivity timeout exceeded, more than ' . $timeout . ' seconds elapsed from last data received',
-                0,
-                $e
-            );
+            if ($readingCancellation->isRequested()) {
+                throw new TimeoutException('Allowed transfer timeout exceeded, took longer than ' . $request->getTransferTimeout() . ' s', 0, $e);
+            }
+
+            throw new TimeoutException('Inactivity timeout exceeded, more than ' . $timeout . ' seconds elapsed from last data received', 0, $e);
         } catch (\Throwable $e) {
             $this->close();
             throw new SocketException('Receiving the response headers failed: ' . $e->getMessage(), 0, $e);

--- a/test/TimeoutTest.php
+++ b/test/TimeoutTest.php
@@ -60,7 +60,7 @@ class TimeoutTest extends AsyncTestCase
 
     public function testTimeoutDuringConnect(): void
     {
-        $this->setTimeout(0.6);
+        $this->setTimeout(1);
 
         $connector = $this->createMock(Socket\SocketConnector::class);
         $connector->method('connect')
@@ -99,7 +99,7 @@ class TimeoutTest extends AsyncTestCase
             }
         });
 
-        $this->setTimeout(0.6);
+        $this->setTimeout(1);
 
         try {
             $uri = "https://" . $server->getAddress() . "/";
@@ -223,7 +223,7 @@ class TimeoutTest extends AsyncTestCase
             }
         });
 
-        $this->setTimeout(0.6);
+        $this->setTimeout(1);
 
         try {
             $uri = "https://" . $server->getAddress() . "/";

--- a/test/TimeoutTest.php
+++ b/test/TimeoutTest.php
@@ -275,4 +275,46 @@ class TimeoutTest extends AsyncTestCase
             $server->close();
         }
     }
+
+    public function testTransferTimeoutDuringRequest(): void
+    {
+        $server = listen("tcp://127.0.0.1:0");
+
+        $this->setTimeout(1);
+
+        try {
+            $uri = "http://" . $server->getAddress() . "/";
+
+            $request = new Request($uri);
+            $request->setTransferTimeout(0.1);
+
+            $this->expectException(TimeoutException::class);
+            $this->expectExceptionMessage("Allowed transfer timeout exceeded, took longer than 0.1 s");
+
+            $this->client->request($request);
+        } finally {
+            $server->close();
+        }
+    }
+
+    public function testInactivityTimeoutDuringRequest(): void
+    {
+        $server = listen("tcp://127.0.0.1:0");
+
+        $this->setTimeout(1);
+
+        try {
+            $uri = "http://" . $server->getAddress() . "/";
+
+            $request = new Request($uri);
+            $request->setInactivityTimeout(0.1);
+
+            $this->expectException(TimeoutException::class);
+            $this->expectExceptionMessage("Inactivity timeout exceeded, more than 0.1 seconds elapsed from last data received");
+
+            $this->client->request($request);
+        } finally {
+            $server->close();
+        }
+    }
 }


### PR DESCRIPTION
I found out that when setting a TransferTimeout limit on a request, the thrown exception is a `SocketException` instead of a `TimeoutException`. This issue only affects HTTP connections, HTTP/2 connections correctly throw `TimeoutException` in such cases as expected.
This change makes the code throw a `TimeoutException` instead of a `SocketException` when a connection session exceeds the TransferTimeout period.

Closes https://github.com/amphp/http-client/issues/379