### PR TITLE
Fix DecompressResponse Interceptor skipping decompression when Accept-Encoding is set manually

### DIFF
--- a/src/HttpClientBuilder.php
+++ b/src/HttpClientBuilder.php
@@ -35,7 +35,7 @@ final class HttpClientBuilder
 
     private ?SetRequestHeaderIfUnset $defaultAcceptInterceptor;
 
-    private ?DecompressResponse $defaultCompressionHandler;
+    private bool $compression = true;
 
     /** @var ApplicationInterceptor[] */
     private array $applicationInterceptors = [];
@@ -56,7 +56,6 @@ final class HttpClientBuilder
         $this->retryInterceptor = new RetryRequests(2);
         $this->defaultAcceptInterceptor = new SetRequestHeaderIfUnset('accept', '*/*');
         $this->defaultUserAgentInterceptor = new SetRequestHeaderIfUnset('user-agent', 'amphp/http-client/5.x');
-        $this->defaultCompressionHandler = new DecompressResponse;
     }
 
     public function build(): HttpClient
@@ -75,8 +74,9 @@ final class HttpClientBuilder
             $client = $client->intercept($this->defaultUserAgentInterceptor);
         }
 
-        if ($this->defaultCompressionHandler) {
-            $client = $client->intercept($this->defaultCompressionHandler);
+        if ($this->compression) {
+            $client = $client->intercept(new SetRequestHeaderIfUnset('Accept-Encoding', 'gzip, deflate, identity'));
+            $client = $client->intercept(new DecompressResponse());
         }
 
         foreach ($this->eventListeners as $eventListener) {
@@ -232,7 +232,7 @@ final class HttpClientBuilder
     public function skipAutomaticCompression(): self
     {
         $builder = clone $this;
-        $builder->defaultCompressionHandler = null;
+        $builder->compression = false;
 
         return $builder;
     }

--- a/src/Interceptor/DecompressResponse.php
+++ b/src/Interceptor/DecompressResponse.php
@@ -29,12 +29,9 @@ final class DecompressResponse implements NetworkInterceptor
         Cancellation $cancellation,
         Stream $stream
     ): Response {
-        // If a header is manually set, we won't interfere
-        if ($request->hasHeader('accept-encoding')) {
+        if (!$this->hasZlib) {
             return $stream->request($request, $cancellation);
         }
-
-        $this->addAcceptEncodingHeader($request);
 
         $request->interceptPush(function (Request $request, Response $response): Response {
             return $this->decompressResponse($response);
@@ -43,16 +40,9 @@ final class DecompressResponse implements NetworkInterceptor
         return $this->decompressResponse($stream->request($request, $cancellation));
     }
 
-    private function addAcceptEncodingHeader(Request $request): void
-    {
-        if ($this->hasZlib) {
-            $request->setHeader('Accept-Encoding', 'gzip, deflate, identity');
-        }
-    }
-
     private function decompressResponse(Response $response): Response
     {
-        if (($encoding = $this->determineCompressionEncoding($response))) {
+        if (0 !== $encoding = $this->determineCompressionEncoding($response)) {
             $stream = new DecompressingReadableStream($response->getBody(), $encoding);
 
             $sizeLimit = $response->getRequest()->getBodySizeLimit();
@@ -69,17 +59,9 @@ final class DecompressResponse implements NetworkInterceptor
 
     private function determineCompressionEncoding(Response $response): int
     {
-        if (!$this->hasZlib) {
+        if (null === $contentEncoding = $response->getHeader('content-encoding')) {
             return 0;
         }
-
-        if (!$response->hasHeader("content-encoding")) {
-            return 0;
-        }
-
-        $contentEncoding = $response->getHeader("content-encoding");
-
-        \assert($contentEncoding !== null);
 
         $contentEncodingHeader = \trim($contentEncoding);
 

--- a/test/ClientHttpBinIntegrationTest.php
+++ b/test/ClientHttpBinIntegrationTest.php
@@ -515,6 +515,7 @@ class ClientHttpBinIntegrationTest extends AsyncTestCase
         $result = \json_decode($response->getBody()->buffer(), true);
 
         self::assertTrue($result['deflated']);
+        self::assertFalse($response->hasHeader('content-encoding'));
     }
 
     public function testInfiniteRedirect(): void


### PR DESCRIPTION
This PR fixes the DecompressResponse Interceptor.
Previously, if the Accept-Encoding header was manually set on a request, the interceptor would skip decompression, resulting in an encoded response body.
With this change, the DecompressResponse Interceptor determines whether to decompress the response based only on the Content-Encoding response header. It will decompress the body if this header contains a supported algorithm, regardless of the request headers.