### PR TITLE
Proposal: TlsException to replace SocketException for TLS handshake errors

### DIFF
--- a/src/Connection/DefaultConnectionFactory.php
+++ b/src/Connection/DefaultConnectionFactory.php
@@ -10,6 +10,7 @@ use Amp\Http\Client\InvalidRequestException;
 use Amp\Http\Client\Request;
 use Amp\Http\Client\SocketException;
 use Amp\Http\Client\TimeoutException;
+use Amp\Http\Client\TlsException;
 use Amp\Socket;
 use Amp\Socket\ClientTlsContext;
 use Amp\Socket\ConnectContext;
@@ -123,7 +124,7 @@ final class DefaultConnectionFactory implements ConnectionFactory
                 if ($tlsState !== Socket\TlsState::Disabled) {
                     $socket->close();
 
-                    throw new SocketException('Failed to setup TLS connection, connection was in an unexpected TLS state (' . $tlsState->name . ')');
+                    throw new TlsException('Failed to setup TLS connection, connection was in an unexpected TLS state (' . $tlsState->name . ')');
                 }
 
                 $socket->setupTls(new CompositeCancellation(
@@ -137,7 +138,7 @@ final class DefaultConnectionFactory implements ConnectionFactory
                 \preg_match('/error:[0-9a-f]*:[^:]*:[^:]*:(.+)$/i', $errorMessage, $matches);
                 $errorMessage = \trim($matches[1] ?? \explode('():', $errorMessage, 2)[1] ?? $errorMessage);
 
-                throw new SocketException(\sprintf(
+                throw new TlsException(\sprintf(
                     "Connection to '%s' @ '%s' closed during TLS handshake: %s",
                     $authority,
                     $socket->getRemoteAddress()->toString(),
@@ -161,7 +162,7 @@ final class DefaultConnectionFactory implements ConnectionFactory
             if ($tlsInfo === null) {
                 $socket->close();
 
-                throw new SocketException(\sprintf(
+                throw new TlsException(\sprintf(
                     "Socket closed after TLS handshake with '%s' @ '%s'",
                     $authority,
                     $socket->getRemoteAddress()->toString()

--- a/src/SocketException.php
+++ b/src/SocketException.php
@@ -2,6 +2,6 @@
 
 namespace Amp\Http\Client;
 
-final class SocketException extends HttpException
+class SocketException extends HttpException
 {
 }

--- a/src/TlsException.php
+++ b/src/TlsException.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Amp\Http\Client;
+
+final class TlsException extends HttpException
+{
+}

--- a/src/TlsException.php
+++ b/src/TlsException.php
@@ -2,6 +2,6 @@
 
 namespace Amp\Http\Client;
 
-final class TlsException extends HttpException
+final class TlsException extends SocketException
 {
 }

--- a/test/ClientBadSslIntegrationTest.php
+++ b/test/ClientBadSslIntegrationTest.php
@@ -19,7 +19,7 @@ final class ClientBadSslIntegrationTest extends AsyncTestCase
     {
         $request = new Request('https://self-signed.badssl.com/');
 
-        $this->expectException(SocketException::class);
+        $this->expectException(TlsException::class);
         $this->expectExceptionMessageMatches("/^Connection to 'self-signed.badssl.com:443' @ '.+' closed during TLS handshake: certificate verify failed$/");
 
         $this->client->request($request);
@@ -29,7 +29,7 @@ final class ClientBadSslIntegrationTest extends AsyncTestCase
     {
         $request = new Request('https://wrong.host.badssl.com/');
 
-        $this->expectException(SocketException::class);
+        $this->expectException(TlsException::class);
         $this->expectExceptionMessageMatches("/^Connection to 'wrong.host.badssl.com:443' @ '.+' closed during TLS handshake: Peer certificate CN=`\*.badssl.com' did not match expected CN=`wrong.host.badssl.com'$/");
 
         $this->client->request($request);
@@ -39,7 +39,7 @@ final class ClientBadSslIntegrationTest extends AsyncTestCase
     {
         $request = new Request('https://dh512.badssl.com/');
 
-        $this->expectException(SocketException::class);
+        $this->expectException(TlsException::class);
         $this->expectExceptionMessageMatches("/^Connection to 'dh512.badssl.com:443' @ '.+' closed during TLS handshake: dh key too small$/");
 
         $this->client->request($request);


### PR DESCRIPTION
This PR proposes a new TlsException to replace SocketException in cases where an exception occurs during the TLS handshake.

Related: https://github.com/amphp/http-client/issues/379
