### PR TITLE
Enhance TLS handshake error message with additional details from previous exception

### DIFF
--- a/src/Connection/DefaultConnectionFactory.php
+++ b/src/Connection/DefaultConnectionFactory.php
@@ -134,8 +134,8 @@ final class DefaultConnectionFactory implements ConnectionFactory
                 $socket->close();
 
                 $errorMessage = $streamException->getMessage();
-                \preg_match('/error:[0-9a-f]+:[^:]+:[^:]+:(.+)$/i', $errorMessage, $matches);
-                $errorMessage = \trim($matches[1] ?? \explode("():", $errorMessage, 2)[1] ?? $errorMessage);
+                \preg_match('/error:[0-9a-f]*:[^:]*:[^:]*:(.+)$/i', $errorMessage, $matches);
+                $errorMessage = \trim($matches[1] ?? \explode('():', $errorMessage, 2)[1] ?? $errorMessage);
 
                 throw new SocketException(\sprintf(
                     "Connection to '%s' @ '%s' closed during TLS handshake: %s",

--- a/src/Connection/DefaultConnectionFactory.php
+++ b/src/Connection/DefaultConnectionFactory.php
@@ -133,10 +133,15 @@ final class DefaultConnectionFactory implements ConnectionFactory
             } catch (StreamException $streamException) {
                 $socket->close();
 
+                $errorMessage = $streamException->getMessage();
+                \preg_match('/error:[0-9a-f]+:[^:]+:[^:]+:(.+)$/i', $errorMessage, $matches);
+                $errorMessage = \trim($matches[1] ?? \explode("():", $errorMessage, 2)[1] ?? $errorMessage);
+
                 throw new SocketException(\sprintf(
-                    "Connection to '%s' @ '%s' closed during TLS handshake",
+                    "Connection to '%s' @ '%s' closed during TLS handshake: %s",
                     $authority,
-                    $socket->getRemoteAddress()->toString()
+                    $socket->getRemoteAddress()->toString(),
+                    $errorMessage,
                 ), 0, $streamException);
             } catch (CancelledException) {
                 $socket->close();

--- a/test/ClientBadSslIntegrationTest.php
+++ b/test/ClientBadSslIntegrationTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Amp\Http\Client;
+
+use Amp\PHPUnit\AsyncTestCase;
+
+final class ClientBadSslIntegrationTest extends AsyncTestCase
+{
+    private HttpClient $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = (new HttpClientBuilder)->retry(0)->build();
+    }
+
+    public function testSelfSignedCertificate(): void
+    {
+        $request = new Request('https://self-signed.badssl.com/');
+
+        $this->expectException(SocketException::class);
+        $this->expectExceptionMessageMatches("/^Connection to 'self-signed.badssl.com:443' @ '.+' closed during TLS handshake: certificate verify failed$/");
+
+        $this->client->request($request);
+    }
+
+    public function testWrongHostCertificate(): void
+    {
+        $request = new Request('https://wrong.host.badssl.com/');
+
+        $this->expectException(SocketException::class);
+        $this->expectExceptionMessageMatches("/^Connection to 'wrong.host.badssl.com:443' @ '.+' closed during TLS handshake: Peer certificate CN=`\*.badssl.com' did not match expected CN=`wrong.host.badssl.com'$/");
+
+        $this->client->request($request);
+    }
+
+    public function testDhKeyTooSmall(): void
+    {
+        $request = new Request('https://dh512.badssl.com/');
+
+        $this->expectException(SocketException::class);
+        $this->expectExceptionMessageMatches("/^Connection to 'dh512.badssl.com:443' @ '.+' closed during TLS handshake: dh key too small$/");
+
+        $this->client->request($request);
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/amphp/http-client/issues/360

This change extracts additional information from the previous exception to provide more details in the '_Connection to '%s' @ '%s' closed during TLS handshake_' error message. It tries to filter out unnecessary text and retains details."

For example, previous exceptions could generate the following text:
```
TLS negotiation failed: stream_socket_enable_crypto(): SSL operation failed with code 1. OpenSSL Error messages:
error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed
```
Then exception message will be:
```
Connection to 'self-signed.badssl.com:443' @ '104.154.89.105:443' closed during TLS handshake: certificate verify failed
```

Previous exception message:
```
TLS negotiation failed: stream_socket_enable_crypto(): Peer certificate CN=`*.badssl.com' did not match expected CN=`wrong.host.badssl.com'
```

Exception message:
```
Connection to 'wrong.host.badssl.com:443' @ '104.154.89.105:443' closed during TLS handshake: Peer certificate CN=`*.badssl.com' did not match expected CN=`wrong.host.badssl.com'
```


Website with invalid certificates for test:
https://badssl.com/