### PR TITLE
Update CI to support PHP 8.4 & 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,18 @@ jobs:
           - operating-system: 'ubuntu-latest'
             php-version: '8.3'
 
+          - operating-system: 'ubuntu-latest'
+            php-version: '8.4'
+
+          - operating-system: 'ubuntu-latest'
+            php-version: '8.5'
+
           - operating-system: 'windows-latest'
-            php-version: '8.3'
+            php-version: '8.5'
             job-description: 'on Windows'
 
           - operating-system: 'macos-latest'
-            php-version: '8.3'
+            php-version: '8.5'
             job-description: 'on macOS'
 
     name: PHP ${{ matrix.php-version }} ${{ matrix.job-description }}

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "amphp/http-server": "^3",
         "kelunik/link-header-rfc5988": "^1",
         "psalm/phar": "~5.23",
-        "laminas/laminas-diactoros": "^2.3"
+        "laminas/laminas-diactoros": "^3.7"
     },
     "suggest": {
         "ext-zlib": "Allows using compression for response bodies.",


### PR DESCRIPTION
I believe httpbin is ... super slow today (it's at least on my side).

Wouldn't be a good idea to include the docker in the CI ? (btw it's not that easy because the docker alone is not enough, it needs nginx on top of it)

<img width="616" height="644" alt="Capture d’écran 2025-11-28 à 15 12 40" src="https://github.com/user-attachments/assets/b1e1d8c7-7194-4487-9ff0-58b2424280e0" />
